### PR TITLE
Updated CFLs

### DIFF
--- a/Positions.xml
+++ b/Positions.xml
@@ -624,7 +624,7 @@
       <Window Type="ADEP" Beacon="YMAV" Visible="true" />
     </Strips>
     <CFL QuickLevel="24000">
-      <AdditionalLevels>1600,1900,2300,2600,2700,2900,3100,3700,3300,4100.4700</AdditionalLevels>
+      <AdditionalLevels>1600,1900,2300,2600,2700,2900,3100,3700,3300,4100,4700</AdditionalLevels>
     </CFL>
     <ArrivalLists>
       <Airport Name="YMML" />

--- a/Positions.xml
+++ b/Positions.xml
@@ -21,7 +21,7 @@
       <Window Type="State" State="Announced" Visible="true" />
       <Window Type="State" State="Preactive" Visible="true" />
     </Strips>
-    <CFL QuickLevel="9000" />
+    <CFL QuickLevel="10000" />
     <ArrivalLists>
       <Airport Name="YSSY" />
     </ArrivalLists>
@@ -103,7 +103,7 @@
       <Window Type="State" State="Announced" Visible="true" />
       <Window Type="State" State="Preactive" Visible="true" />
     </Strips>
-    <CFL QuickLevel="9000" />
+    <CFL QuickLevel="25000" />
     <ArrivalLists>
       <Airport Name="YMHB" />
       <Airport Name="YMLT" />
@@ -133,7 +133,7 @@
       <Window Type="State" State="Announced" Visible="true" />
       <Window Type="State" State="Preactive" Visible="true" />
     </Strips>
-    <CFL QuickLevel="9000" />
+    <CFL QuickLevel="25000" />
     <ControllerInfo>
       <Line>Melbourne Centre</Line>
       <Line>ATC feedback - feedback.vatpac.org</Line>
@@ -158,7 +158,7 @@
       <Window Type="State" State="Announced" Visible="true" />
       <Window Type="State" State="Preactive" Visible="true" />
     </Strips>
-    <CFL QuickLevel="18000" />
+    <CFL QuickLevel="25000" />
     <ControllerInfo>
       <Line>Brisbane Centre</Line>
       <Line>ATC feedback - feedback.vatpac.org</Line>
@@ -214,7 +214,7 @@
       <Window Type="State" State="Announced" Visible="true" />
       <Window Type="State" State="Preactive" Visible="true" />
     </Strips>
-    <CFL QuickLevel="9000" />
+    <CFL QuickLevel="25000" />
     <ControllerInfo>
       <Line>Brisbane Centre</Line>
       <Line>ATC feedback - feedback.vatpac.org</Line>
@@ -269,7 +269,7 @@
       <Window Type="State" State="Announced" Visible="true" />
       <Window Type="State" State="Preactive" Visible="true" />
     </Strips>
-    <CFL QuickLevel="9000" />
+    <CFL QuickLevel="25000" />
     <ArrivalLists>
       <Airport Name="YBAS" />
     </ArrivalLists>
@@ -333,7 +333,7 @@
       <Window Type="State" State="Announced" Visible="true" />
       <Window Type="State" State="Preactive" Visible="true" />
     </Strips>
-    <CFL QuickLevel="9000" />
+    <CFL QuickLevel="25000" />
     <ControllerInfo>
       <Line>Melbourne Centre</Line>
       <Line>ATC feedback - feedback.vatpac.org</Line>
@@ -360,7 +360,7 @@
       <Window Type="State" State="Announced" Visible="true" />
       <Window Type="State" State="Preactive" Visible="true" />
     </Strips>
-    <CFL QuickLevel="9000" />
+    <CFL QuickLevel="7000" />
     <ArrivalLists>
       <Airport Name="YBCS" />
     </ArrivalLists>
@@ -624,7 +624,7 @@
       <Window Type="ADEP" Beacon="YMAV" Visible="true" />
     </Strips>
     <CFL QuickLevel="24000">
-      <AdditionalLevels>1600,1900,2100,2300,2700,2800,2900,3100,3300</AdditionalLevels>
+      <AdditionalLevels>1600,1900,2100,2300,2600,2700,2900,3100,3300,4100,4700</AdditionalLevels>
     </CFL>
     <ArrivalLists>
       <Airport Name="YMML" />
@@ -667,7 +667,7 @@
       <Window Type="ADEP" Beacon="YSSY" Visible="true" />
     </Strips>
     <CFL QuickLevel="28000">
-      <AdditionalLevels>1600,1800,2100,2200,2700,5200</AdditionalLevels>
+      <AdditionalLevels>1600,1800,2100,2200,2700,3700,4900,5200</AdditionalLevels>
     </CFL>
     <ArrivalLists>
       <Airport Name="YSSY" />
@@ -711,7 +711,7 @@
       <Window Type="ADEP" Beacon="YBCG" Visible="true" />
     </Strips>
     <CFL QuickLevel="18000">
-      <AdditionalLevels>3300,4400,5100</AdditionalLevels>
+      <AdditionalLevels>1700,1800,1900,2400,2900,3300,3400,3800,4400,5100</AdditionalLevels>
     </CFL>
     <ArrivalLists>
       <Airport Name="YBBN" />
@@ -756,6 +756,9 @@
     <Strips Mode="Beacon" Sort="Alpha">
       <Window Type="ADEP" Beacon="YSCB" Visible="true" />
     </Strips>
+    <CFL QuickLevel="24000">
+      <AdditionalLevels>4300,4400,4800,5100,5400,5600,6200,6700,7100,7700</AdditionalLevels>
+    </CFL>
     <ArrivalLists>
       <Airport Name="YSCB" />
     </ArrivalLists>
@@ -791,7 +794,7 @@
       <Window Type="ADEP" Beacon="YPPH" Visible="true" />
     </Strips>
     <CFL QuickLevel="18000">
-      <AdditionalLevels>2800</AdditionalLevels>
+      <AdditionalLevels>1900,2700,2800,3100,3400,3700</AdditionalLevels>
     </CFL>
     <ArrivalLists>
       <Airport Name="YPPH" />
@@ -827,6 +830,9 @@
     <Strips Mode="Beacon" Sort="Alpha">
       <Window Type="ADEP" Beacon="YBCS" Visible="true" />
     </Strips>
+    <CFL QuickLevel="18000">
+      <AdditionalLevels>3300,3900,4700,4900,5200,5400,5700,5800,6800</AdditionalLevels>
+    </CFL>
     <ArrivalLists>
       <Airport Name="YBCS" />
     </ArrivalLists>
@@ -861,7 +867,7 @@
       <Window Type="ADEP" Beacon="YBTL" Visible="true" />
     </Strips>
     <CFL QuickLevel="18000">
-      <AdditionalLevels>3600,4700,5200</AdditionalLevels>
+      <AdditionalLevels>2700,3400,3600,4700,5100,5200</AdditionalLevels>
     </CFL>
     <ArrivalLists>
       <Airport Name="YBTL" />
@@ -947,7 +953,9 @@
     <Strips Mode="Beacon" Sort="Alpha">
       <Window Type="ADEP" Beacon="YPDN" Visible="true" />
     </Strips>
-    <CFL QuickLevel="18000" />
+    <CFL QuickLevel="18000">
+      <AdditionalLevels>1700</AdditionalLevels>
+    <CFL/>
     <ArrivalLists>
       <Airport Name="YPDN" />
     </ArrivalLists>
@@ -981,7 +989,7 @@
       <Window Type="ADEP" Beacon="YMAY" Visible="true" />
     </Strips>
     <CFL QuickLevel="4500">
-      <AdditionalLevels>3400</AdditionalLevels>
+      <AdditionalLevels>3400,5400</AdditionalLevels>
     </CFL>
     <ArrivalLists>
       <Airport Name="YMAY" />
@@ -1009,7 +1017,7 @@
       <Window Type="ADEP" Beacon="YBAS" Visible="true" />
     </Strips>
     <CFL QuickLevel="4500">
-      <AdditionalLevels>3400</AdditionalLevels>
+      <AdditionalLevels>3400,5200</AdditionalLevels>
     </CFL>
     <ArrivalLists>
       <Airport Name="YBAS" />
@@ -1036,7 +1044,7 @@
     <Strips Mode="Beacon" Sort="Alpha">
       <Window Type="ADEP" Beacon="YAMB" Visible="true" />
     </Strips>
-    <CFL QuickLevel="21000">
+    <CFL QuickLevel="8500">
       <AdditionalLevels>3400,3800,5100</AdditionalLevels>
     </CFL>
     <ArrivalLists>
@@ -1131,7 +1139,7 @@
     <Strips Mode="Beacon" Sort="Alpha">
       <Window Type="ADEP" Beacon="YMES" Visible="true" />
     </Strips>
-    <CFL QuickLevel="21000">
+    <CFL QuickLevel="12500">
       <AdditionalLevels>1900,3400,3500,4400</AdditionalLevels>
     </CFL>
     <ArrivalLists>
@@ -1435,7 +1443,7 @@
     <Strips Mode="Beacon" Sort="Alpha">
       <Window Type="ADEP" Beacon="YSNW" Visible="true" />
     </Strips>
-    <CFL QuickLevel="12500">
+    <CFL QuickLevel="8500">
       <AdditionalLevels>2300,4300</AdditionalLevels>
     </CFL>
     <ArrivalLists>

--- a/Positions.xml
+++ b/Positions.xml
@@ -624,7 +624,7 @@
       <Window Type="ADEP" Beacon="YMAV" Visible="true" />
     </Strips>
     <CFL QuickLevel="24000">
-      <AdditionalLevels>1600,1900,2300,2700,2900,3100,3300,4100</AdditionalLevels>
+      <AdditionalLevels>1600,1900,2300,2600,2700,2900,3100,3700,3300,4100.4700</AdditionalLevels>
     </CFL>
     <ArrivalLists>
       <Airport Name="YMML" />
@@ -667,7 +667,7 @@
       <Window Type="ADEP" Beacon="YSSY" Visible="true" />
     </Strips>
     <CFL QuickLevel="28000">
-      <AdditionalLevels>1600,1800,2100,2200,2700</AdditionalLevels>
+      <AdditionalLevels>1600,1800,2100,2200,2700,3700</AdditionalLevels>
     </CFL>
     <ArrivalLists>
       <Airport Name="YSSY" />
@@ -711,7 +711,7 @@
       <Window Type="ADEP" Beacon="YBCG" Visible="true" />
     </Strips>
     <CFL QuickLevel="18000">
-      <AdditionalLevels>1700,1800,1900,2400,2900,3400,3800,4400</AdditionalLevels>
+      <AdditionalLevels>1700,1800,1900,2400,2900,3400,3800,4400,5100</AdditionalLevels>
     </CFL>
     <ArrivalLists>
       <Airport Name="YBBN" />
@@ -757,7 +757,7 @@
       <Window Type="ADEP" Beacon="YSCB" Visible="true" />
     </Strips>
     <CFL QuickLevel="24000">
-      <AdditionalLevels>4300,4400,4800,5100,5400,6200,7500,7700</AdditionalLevels>
+      <AdditionalLevels>4300,4400,4800,5100,5400,6200,6700,7700</AdditionalLevels>
     </CFL>
     <ArrivalLists>
       <Airport Name="YSCB" />
@@ -794,7 +794,7 @@
       <Window Type="ADEP" Beacon="YPPH" Visible="true" />
     </Strips>
     <CFL QuickLevel="18000">
-      <AdditionalLevels>1900,2500,2700,2800,3300</AdditionalLevels>
+      <AdditionalLevels>1900,2700,2800,3100,3300</AdditionalLevels>
     </CFL>
     <ArrivalLists>
       <Airport Name="YPPH" />
@@ -867,7 +867,7 @@
       <Window Type="ADEP" Beacon="YBTL" Visible="true" />
     </Strips>
     <CFL QuickLevel="18000">
-      <AdditionalLevels>2700,3500,3600,4700,5100,5200</AdditionalLevels>
+      <AdditionalLevels>2700,3600,4700,5100,5200</AdditionalLevels>
     </CFL>
     <ArrivalLists>
       <Airport Name="YBTL" />

--- a/Positions.xml
+++ b/Positions.xml
@@ -624,7 +624,7 @@
       <Window Type="ADEP" Beacon="YMAV" Visible="true" />
     </Strips>
     <CFL QuickLevel="24000">
-      <AdditionalLevels>1600,1900,2100,2300,2600,2700,2900,3100,3300,4100,4700</AdditionalLevels>
+      <AdditionalLevels>1600,1900,2300,2700,2900,3100,3300,4100</AdditionalLevels>
     </CFL>
     <ArrivalLists>
       <Airport Name="YMML" />
@@ -667,7 +667,7 @@
       <Window Type="ADEP" Beacon="YSSY" Visible="true" />
     </Strips>
     <CFL QuickLevel="28000">
-      <AdditionalLevels>1600,1800,2100,2200,2700,3700,4900,5200</AdditionalLevels>
+      <AdditionalLevels>1600,1800,2100,2200,2700</AdditionalLevels>
     </CFL>
     <ArrivalLists>
       <Airport Name="YSSY" />
@@ -711,7 +711,7 @@
       <Window Type="ADEP" Beacon="YBCG" Visible="true" />
     </Strips>
     <CFL QuickLevel="18000">
-      <AdditionalLevels>1700,1800,1900,2400,2900,3300,3400,3800,4400,5100</AdditionalLevels>
+      <AdditionalLevels>1700,1800,1900,2400,2900,3400,3800,4400</AdditionalLevels>
     </CFL>
     <ArrivalLists>
       <Airport Name="YBBN" />
@@ -757,7 +757,7 @@
       <Window Type="ADEP" Beacon="YSCB" Visible="true" />
     </Strips>
     <CFL QuickLevel="24000">
-      <AdditionalLevels>4300,4400,4800,5100,5400,5600,6200,6700,7100,7700</AdditionalLevels>
+      <AdditionalLevels>4300,4400,4800,5100,5400,6200,7500,7700</AdditionalLevels>
     </CFL>
     <ArrivalLists>
       <Airport Name="YSCB" />
@@ -794,7 +794,7 @@
       <Window Type="ADEP" Beacon="YPPH" Visible="true" />
     </Strips>
     <CFL QuickLevel="18000">
-      <AdditionalLevels>1900,2700,2800,3100,3400,3700</AdditionalLevels>
+      <AdditionalLevels>1900,2500,2700,2800,3300</AdditionalLevels>
     </CFL>
     <ArrivalLists>
       <Airport Name="YPPH" />
@@ -831,7 +831,7 @@
       <Window Type="ADEP" Beacon="YBCS" Visible="true" />
     </Strips>
     <CFL QuickLevel="18000">
-      <AdditionalLevels>3300,3900,4700,4900,5200,5400,5700,5800,6800</AdditionalLevels>
+      <AdditionalLevels>3300,3900,4700,4900,5200,5400,5800,6800</AdditionalLevels>
     </CFL>
     <ArrivalLists>
       <Airport Name="YBCS" />
@@ -867,7 +867,7 @@
       <Window Type="ADEP" Beacon="YBTL" Visible="true" />
     </Strips>
     <CFL QuickLevel="18000">
-      <AdditionalLevels>2700,3400,3600,4700,5100,5200</AdditionalLevels>
+      <AdditionalLevels>2700,3500,3600,4700,5100,5200</AdditionalLevels>
     </CFL>
     <ArrivalLists>
       <Airport Name="YBTL" />
@@ -1017,7 +1017,7 @@
       <Window Type="ADEP" Beacon="YBAS" Visible="true" />
     </Strips>
     <CFL QuickLevel="4500">
-      <AdditionalLevels>3400,5200</AdditionalLevels>
+      <AdditionalLevels>5200</AdditionalLevels>
     </CFL>
     <ArrivalLists>
       <Airport Name="YBAS" />
@@ -1139,7 +1139,7 @@
     <Strips Mode="Beacon" Sort="Alpha">
       <Window Type="ADEP" Beacon="YMES" Visible="true" />
     </Strips>
-    <CFL QuickLevel="12500">
+    <CFL QuickLevel="21000">
       <AdditionalLevels>1900,3400,3500,4400</AdditionalLevels>
     </CFL>
     <ArrivalLists>
@@ -1443,7 +1443,7 @@
     <Strips Mode="Beacon" Sort="Alpha">
       <Window Type="ADEP" Beacon="YSNW" Visible="true" />
     </Strips>
-    <CFL QuickLevel="8500">
+    <CFL QuickLevel="12500">
       <AdditionalLevels>2300,4300</AdditionalLevels>
     </CFL>
     <ArrivalLists>


### PR DESCRIPTION
Updated CFL Quick Level and Additional Levels for all positions.  Oceanic positions' CFL left at F290 and YPTN left at A100 (not much data available).