### PR TITLE
AIRAC 2207

### DIFF
--- a/Airspace.xml
+++ b/Airspace.xml
@@ -626,15 +626,15 @@
         <SID Name="RUSKA6" Type="NonJet" />
         <SID Name="VANDI6" Type="NonJet" />
         <STAR Name="DONY9A" ApproachName="RNPX" />
-        <STAR Name="DONY9U" OpDataFlag="U" ApproachName="RNP-ARU" />
+        <STAR Name="DONY9U" OpDataFlag="U" />
         <STAR Name="GATO9A" ApproachName="RNPX" />
-        <STAR Name="GATO9U" OpDataFlag="U" ApproachName="RNP-ARU" />
+        <STAR Name="GATO9U" OpDataFlag="U" />
         <STAR Name="VEGP7A" ApproachName="RNPX" />
-        <STAR Name="VEGP7P" OpDataFlag="P" ApproachName="RNP-ARP" />
-        <STAR Name="VEGP7U" OpDataFlag="U" ApproachName="RNP-ARU" />
+        <STAR Name="VEGP7P" OpDataFlag="P" />
+        <STAR Name="VEGP7U" OpDataFlag="U" />
         <STAR Name="WANG2A" ApproachName="RNPX" />
-        <STAR Name="WANG2P" OpDataFlag="P" ApproachName="RNP-ARP" />
-        <STAR Name="WANG2U" OpDataFlag="U" ApproachName="RNP-ARU" />
+        <STAR Name="WANG2P" OpDataFlag="P" />
+        <STAR Name="WANG2U" OpDataFlag="U" />
       </Runway>
       <Runway Name="18" DataRunway="18">
         <SID Name="DN7" Default="True" />
@@ -650,14 +650,14 @@
         <SID Name="RUSKA6" Type="NonJet" />
         <SID Name="VANDI6" Type="NonJet" />
         <STAR Name="DONY9A" ApproachName="LOC" />
-        <STAR Name="DONY9U" OpDataFlag="U" ApproachName="RNP-ARU" />
+        <STAR Name="DONY9U" OpDataFlag="U" ApproachName="LOC" />
         <STAR Name="GATO9A" ApproachName="LOC" />
-        <STAR Name="GATO9U" OpDataFlag="U" ApproachName="RNP-ARU" />
+        <STAR Name="GATO9U" OpDataFlag="U" ApproachName="LOC" />
         <STAR Name="VEGP7A" ApproachName="LOC" />
-        <STAR Name="VEGP7U" OpDataFlag="U" ApproachName="RNP-ARU" />
+        <STAR Name="VEGP7U" OpDataFlag="U" ApproachName="LOC" />
         <STAR Name="WANG2A" ApproachName="LOC" />
-        <STAR Name="WANG2P" OpDataFlag="P" ApproachName="RNP-ARP" />
-        <STAR Name="WANG2U" OpDataFlag="U" ApproachName="RNP-ARU" />
+        <STAR Name="WANG2P" OpDataFlag="P" />
+        <STAR Name="WANG2U" OpDataFlag="U" ApproachName="LOC" />
       </Runway>
       <Runway Name="36" DataRunway="36">
         <SID Name="DN7" />
@@ -7937,10 +7937,6 @@ BOFOR
     <Point Name="DN438" Type="Fix">-122208.900+1310035.600</Point>
     <Point Name="DN444" Type="Fix">-122717.200+1310002.300</Point>
     <Point Name="DN448" Type="Fix">-123200.700+1305824.900</Point>
-    <Point Name="DN450" Type="Fix">-121734.700+1305932.600</Point>
-    <Point Name="DN458" Type="Fix">-121410.700+1304927.300</Point>
-    <Point Name="DN460" Type="Fix">-121255.700+1304545.000</Point>
-    <Point Name="DN464" Type="Fix">-121935.700+1310532.700</Point>
     <Point Name="DN81C" Type="Fix">-094524.000+1321530.000</Point>
     <Point Name="DN82C" Type="Fix">-140900.000+1282600.000</Point>
     <Point Name="DN83C" Type="Fix">-120730.000+1275230.000</Point>
@@ -8941,6 +8937,17 @@ BOFOR
     <Point Name="HSMWH" Type="Fix">-363320.300+1421121.200</Point>
     <Point Name="HSMWI" Type="Fix">-364010.400+1415728.600</Point>
     <Point Name="HSMWM" Type="Fix">-364008.100+1420954.600</Point>
+    <Point Name="HT2ED" Type="Fix">-200058.090+1463010.690</Point>
+    <Point Name="HT2EE" Type="Fix">-195514.800+1463052.620</Point>
+    <Point Name="HT2EF" Type="Fix">-200001.240+1462132.060</Point>
+    <Point Name="HT2EH" Type="Fix">-200350.030+1461403.210</Point>
+    <Point Name="HT2EI" Type="Fix">-195738.090+1462612.410</Point>
+    <Point Name="HT2WA" Type="Fix">-201234.760+1460723.470</Point>
+    <Point Name="HT2WB" Type="Fix">-200959.300+1460156.620</Point>
+    <Point Name="HT2WC" Type="Fix">-200416.160+1460239.620</Point>
+    <Point Name="HT2WF" Type="Fix">-200513.940+1461118.340</Point>
+    <Point Name="HT2WH" Type="Fix">-200125.270+1461847.310</Point>
+    <Point Name="HT2WI" Type="Fix">-200736.680+1460637.550</Point>
     <Point Name="HTINA" Type="Fix">-201254.400+1484359.900</Point>
     <Point Name="HTINC" Type="Fix">-200725.800+1484552.900</Point>
     <Point Name="HTIND" Type="Fix">-200713.500+1485158.300</Point>
@@ -11747,13 +11754,9 @@ BOFOR
     <Point Name="RCG10" Type="Fix">-282811.400+1533456.500</Point>
     <Point Name="RCG12" Type="Fix">-281352.100+1533220.400</Point>
     <Point Name="RCG23" Type="Fix">-280802.100+1533108.700</Point>
-    <Point Name="RDN11" Type="Fix">-121712.300+1304415.500</Point>
-    <Point Name="RDN12" Type="Fix">-122351.800+1310403.600</Point>
     <Point Name="RDN13" Type="Fix">-122432.200+1305946.300</Point>
     <Point Name="RDN14" Type="Fix">-123214.500+1304451.300</Point>
-    <Point Name="RDN16" Type="Fix">-121827.300+1304757.800</Point>
     <Point Name="RDN17" Type="Fix">-122020.800+1304718.200</Point>
-    <Point Name="RDN19" Type="Fix">-122151.200+1305803.300</Point>
     <Point Name="RDN22" Type="Fix">-122938.900+1305913.400</Point>
     <Point Name="RDN23" Type="Fix">-122505.700+1304538.800</Point>
     <Point Name="REBEG" Type="Fix">-255829.400+1530646.000</Point>
@@ -17043,20 +17046,6 @@ BOFOR
       <Transition Name="UPSEN">UPSEN/IGBOV/DN407/-12.427845+130.719496/-12.406284+130.720009/-12.387876+130.731518/-12.377552+130.750906/-12.378079+130.772981/-12.378420+130.774016/DN404</Transition>
       <Transition Name="WOKKI">WOKKI/GUPOD/DN422/-12.299439+130.802345/-12.298133+130.780316/-12.307789+130.760577/-12.325794+130.748422/-12.347324+130.747109/-12.366610+130.756993/-12.378485+130.775426/-12.378693+130.776182/DN404</Transition>
       <Route>NASUX/DN404</Route>
-    </Approach>
-    <Approach Name="RNP-ARP" Airport="YPDN" Runway="11">
-      <Transition Name="KITTY">KITTY/TOSOB/DN412/-12.457633+130.746873/-12.452737+130.736928/-12.445472+130.728637/-12.436359+130.722556/-12.435797+130.722317</Transition>
-      <Transition Name="UPSEN">UPSEN/IGBOV</Transition>
-      <Route>DN407/-12.427845+130.719496/-12.406295+130.720395/-12.388086+130.732230/-12.378095+130.751800/-12.377467+130.766602/DN404/DN11T</Route>
-    </Approach>
-    <Approach Name="RNP-ARP" Airport="YPDN" Runway="29">
-      <Route>KITTY/GUMUR/DN448/-12.533533+130.973599/-12.535214+130.995618/-12.525893+131.015543/-12.508096+131.028022/-12.486591+131.029714/-12.467141+131.020166/-12.458983+131.010424/DN444/DN432/DN29T</Route>
-    </Approach>
-    <Approach Name="RNP-ARU" Airport="YPDN" Runway="11">
-      <Route>NASUX/DN404/DN11T</Route>
-    </Approach>
-    <Approach Name="RNP-ARU" Airport="YPDN" Runway="29">
-      <Route>LAPAR/DN432/DN29T</Route>
     </Approach>
     <Approach Name="RNPZ" Airport="YPPH" Runway="03">
       <Route>TIMMY/PERSF/PH03T</Route>

--- a/Airspace.xml
+++ b/Airspace.xml
@@ -72,16 +72,16 @@
         <SID Name="BIXAD1" />
         <SID Name="BN4" Default="True" />
         <SID Name="WACKO3" />
-        <STAR Name="BLAK4A" ApproachName="GNSSZ" />
-        <STAR Name="ENLI1A" ApproachName="GNSSZ" />
-        <STAR Name="GOMO2A" ApproachName="GNSSZ" />
-        <STAR Name="MORB1A" ApproachName="GNSSZ" />
+        <STAR Name="BLAK4A" ApproachName="RNPZ" />
+        <STAR Name="ENLI1A" ApproachName="RNPZ" />
+        <STAR Name="GOMO2A" ApproachName="RNPZ" />
+        <STAR Name="MORB1A" ApproachName="RNPZ" />
         <STAR Name="MORB1V" />
-        <STAR Name="SMOK9A" ApproachName="GNSSZ" />
-        <STAR Name="SMOK9X" OpDataFlag="X" ApproachName="RNPX" />
-        <STAR Name="TEBO1A" ApproachName="GNSSZ" />
-        <STAR Name="UGTU1A" ApproachName="GNSSZ" />
-        <STAR Name="WODY1A" ApproachName="GNSSZ" />
+        <STAR Name="SMOK9A" ApproachName="RNPZ" />
+        <STAR Name="SMOK9X" OpDataFlag="X" ApproachName="RNP-ARX" />
+        <STAR Name="TEBO1A" ApproachName="RNPZ" />
+        <STAR Name="UGTU1A" ApproachName="RNPZ" />
+        <STAR Name="WODY1A" ApproachName="RNPZ" />
         <STAR Name="WODY1V" />
       </Runway>
       <Runway Name="01R" DataRunway="01R">
@@ -91,20 +91,20 @@
         <SID Name="SANEG1" />
         <SID Name="SCOTT3" />
         <SID Name="WACKO3" />
-        <STAR Name="BLAK4A" ApproachName="GNSSZ" />
-        <STAR Name="BLAK4X" OpDataFlag="X" ApproachName="RNPX" />
-        <STAR Name="ENLI1A" ApproachName="GNSSZ" />
-        <STAR Name="GOMO2A" ApproachName="GNSSZ" />
+        <STAR Name="BLAK4A" ApproachName="RNPZ" />
+        <STAR Name="BLAK4X" OpDataFlag="X" ApproachName="RNP-ARX" />
+        <STAR Name="ENLI1A" ApproachName="RNPZ" />
+        <STAR Name="GOMO2A" ApproachName="RNPZ" />
         <STAR Name="GOMO2V" />
-        <STAR Name="GOMO2X" OpDataFlag="X" ApproachName="RNPX" />
-        <STAR Name="MORB1A" ApproachName="GNSSZ" />
-        <STAR Name="SMOK9A" ApproachName="GNSSZ" />
-        <STAR Name="SMOK9M" OpDataFlag="M" ApproachName="RNPM" />
-        <STAR Name="TEBO1A" ApproachName="GNSSZ" />
-        <STAR Name="TEBO1X" OpDataFlag="X" ApproachName="RNPX" />
-        <STAR Name="UGTU1A" ApproachName="GNSSZ" />
-        <STAR Name="UGTU1X" OpDataFlag="X" ApproachName="RNPX" />
-        <STAR Name="WODY1A" ApproachName="GNSSZ" />
+        <STAR Name="GOMO2X" OpDataFlag="X" ApproachName="RNP-ARX" />
+        <STAR Name="MORB1A" ApproachName="RNPZ" />
+        <STAR Name="SMOK9A" ApproachName="RNPZ" />
+        <STAR Name="SMOK9M" OpDataFlag="M" ApproachName="RNP-ARM" />
+        <STAR Name="TEBO1A" ApproachName="RNPZ" />
+        <STAR Name="TEBO1X" OpDataFlag="X" ApproachName="RNP-ARX" />
+        <STAR Name="UGTU1A" ApproachName="RNPZ" />
+        <STAR Name="UGTU1X" OpDataFlag="X" ApproachName="RNP-ARX" />
+        <STAR Name="WODY1A" ApproachName="RNPZ" />
       </Runway>
       <Runway Name="19L" DataRunway="19L">
         <SID Name="BIXAD1" />
@@ -113,35 +113,35 @@
         <SID Name="SANEG1" />
         <SID Name="SCOTT3" />
         <SID Name="WACKO3" />
-        <STAR Name="BLAK4A" ApproachName="GNSSZ" />
-        <STAR Name="BLAK4X" OpDataFlag="X" ApproachName="RNPX" />
-        <STAR Name="ENLI1A" ApproachName="GNSSZ" />
-        <STAR Name="ENLI1X" OpDataFlag="X" ApproachName="RNPX" />
-        <STAR Name="GOMO2A" ApproachName="GNSSZ" />
+        <STAR Name="BLAK4A" ApproachName="RNPZ" />
+        <STAR Name="BLAK4X" OpDataFlag="X" ApproachName="RNP-ARX" />
+        <STAR Name="ENLI1A" ApproachName="RNPZ" />
+        <STAR Name="ENLI1X" OpDataFlag="X" ApproachName="RNP-ARX" />
+        <STAR Name="GOMO2A" ApproachName="RNPZ" />
         <STAR Name="GOMO2V" />
-        <STAR Name="GOMO2X" OpDataFlag="X" ApproachName="RNPX" />
-        <STAR Name="MORB1A" ApproachName="GNSSZ" />
-        <STAR Name="SMOK9A" ApproachName="GNSSZ" />
-        <STAR Name="TEBO1A" ApproachName="GNSSZ" />
-        <STAR Name="UGTU1A" ApproachName="GNSSZ" />
-        <STAR Name="UGTU1X" OpDataFlag="X" ApproachName="RNPX" />
-        <STAR Name="WODY1A" ApproachName="GNSSZ" />
+        <STAR Name="GOMO2X" OpDataFlag="X" ApproachName="RNP-ARX" />
+        <STAR Name="MORB1A" ApproachName="RNPZ" />
+        <STAR Name="SMOK9A" ApproachName="RNPZ" />
+        <STAR Name="TEBO1A" ApproachName="RNPZ" />
+        <STAR Name="UGTU1A" ApproachName="RNPZ" />
+        <STAR Name="UGTU1X" OpDataFlag="X" ApproachName="RNP-ARX" />
+        <STAR Name="WODY1A" ApproachName="RNPZ" />
       </Runway>
       <Runway Name="19R" DataRunway="19R">
         <SID Name="BIXAD1" />
         <SID Name="BN4" Default="True" />
         <SID Name="WACKO3" />
-        <STAR Name="BLAK4A" ApproachName="GNSSZ" />
-        <STAR Name="ENLI1A" ApproachName="GNSSZ" />
-        <STAR Name="ENLI1X" OpDataFlag="X" ApproachName="RNPX" />
-        <STAR Name="GOMO2A" ApproachName="GNSSZ" />
-        <STAR Name="MORB1A" ApproachName="GNSSZ" />
+        <STAR Name="BLAK4A" ApproachName="RNPZ" />
+        <STAR Name="ENLI1A" ApproachName="RNPZ" />
+        <STAR Name="ENLI1X" OpDataFlag="X" ApproachName="RNP-ARX" />
+        <STAR Name="GOMO2A" ApproachName="RNPZ" />
+        <STAR Name="MORB1A" ApproachName="RNPZ" />
         <STAR Name="MORB1V" />
-        <STAR Name="SMOK9A" ApproachName="GNSSZ" />
-        <STAR Name="SMOK9X" OpDataFlag="X" ApproachName="RNPX" />
-        <STAR Name="TEBO1A" ApproachName="GNSSZ" />
-        <STAR Name="UGTU1A" ApproachName="GNSSZ" />
-        <STAR Name="WODY1A" ApproachName="GNSSZ" />
+        <STAR Name="SMOK9A" ApproachName="RNPZ" />
+        <STAR Name="SMOK9X" OpDataFlag="X" ApproachName="RNP-ARX" />
+        <STAR Name="TEBO1A" ApproachName="RNPZ" />
+        <STAR Name="UGTU1A" ApproachName="RNPZ" />
+        <STAR Name="WODY1A" ApproachName="RNPZ" />
         <STAR Name="WODY1V" />
       </Runway>
     </Airport>
@@ -150,10 +150,10 @@
         <SID Name="APAGI5" Type="Jet" />
         <SID Name="CG6" Default="True" />
         <SID Name="CUDGN4" />
-        <STAR Name="BERN1A" ApproachName="GNSSZ" />
-        <STAR Name="BERN1Y" OpDataFlag="Y" ApproachName="RNPY" />
-        <STAR Name="LAMS1A" ApproachName="GNSSZ" />
-        <STAR Name="LAMS1Y" OpDataFlag="Y" ApproachName="RNPY" />
+        <STAR Name="BERN1A" ApproachName="RNPZ" />
+        <STAR Name="BERN1Y" OpDataFlag="Y" ApproachName="RNP-ARY" />
+        <STAR Name="LAMS1A" ApproachName="RNPZ" />
+        <STAR Name="LAMS1Y" OpDataFlag="Y" ApproachName="RNP-ARY" />
       </Runway>
       <Runway Name="17" DataRunway="17">
         <SID Name="CG6" Default="True" />
@@ -162,9 +162,9 @@
         <SID Name="APAGI5" Type="Jet" />
         <SID Name="BURLI5" />
         <SID Name="CG6" Default="True" />
-        <STAR Name="BERN1A" ApproachName="GNSSZ" />
-        <STAR Name="LAMS1A" ApproachName="GNSSZ" />
-        <STAR Name="LAMS1Y" OpDataFlag="Y" ApproachName="RNPY" />
+        <STAR Name="BERN1A" ApproachName="RNPZ" />
+        <STAR Name="LAMS1A" ApproachName="RNPZ" />
+        <STAR Name="LAMS1Y" OpDataFlag="Y" ApproachName="RNP-ARY" />
       </Runway>
       <Runway Name="35" DataRunway="35" />
       <Runway Name="14V" DataRunway="14">
@@ -180,27 +180,27 @@
         <SID Name="NONUM1" Type="NonJet" />
         <SID Name="SWIFT8" Type="Jet" />
         <STAR Name="CODI7A" ApproachName="LOC" />
-        <STAR Name="CODI7X" OpDataFlag="X" ApproachName="RNPX" />
-        <STAR Name="CODI7Z" OpDataFlag="Z" ApproachName="GNSSZ" />
+        <STAR Name="CODI7X" OpDataFlag="X" ApproachName="RNP-ARX" />
+        <STAR Name="CODI7Z" OpDataFlag="Z" ApproachName="RNPZ" />
         <STAR Name="NONU3A" ApproachName="LOC" />
         <STAR Name="NONU3B" OpDataFlag="B" ApproachName="VOR" />
-        <STAR Name="NONU3W" OpDataFlag="W" ApproachName="RNPW" />
-        <STAR Name="NONU3Z" OpDataFlag="Z" ApproachName="GNSSZ" />
+        <STAR Name="NONU3W" OpDataFlag="W" ApproachName="RNP-ARW" />
+        <STAR Name="NONU3Z" OpDataFlag="Z" ApproachName="RNPZ" />
         <STAR Name="SUNY6B" OpDataFlag="B" ApproachName="VOR" />
         <STAR Name="UPOL8A" ApproachName="LOC" />
         <STAR Name="UPOL8B" OpDataFlag="B" ApproachName="VOR" />
-        <STAR Name="UPOL8X" OpDataFlag="X" ApproachName="RNPX" />
-        <STAR Name="UPOL8Z" OpDataFlag="Z" ApproachName="GNSSZ" />
+        <STAR Name="UPOL8X" OpDataFlag="X" ApproachName="RNP-ARX" />
+        <STAR Name="UPOL8Z" OpDataFlag="Z" ApproachName="RNPZ" />
       </Runway>
       <Runway Name="33" DataRunway="33">
         <SID Name="CS2" Default="True" />
         <SID Name="EAZEE2" Type="Jet" />
         <STAR Name="HEND8A" ApproachName="LOC" />
-        <STAR Name="HEND8Y" OpDataFlag="Y" ApproachName="RNPY" />
+        <STAR Name="HEND8Y" OpDataFlag="Y" ApproachName="RNP-ARY" />
         <STAR Name="KEWI2A" ApproachName="LOC" />
-        <STAR Name="KEWI2X" OpDataFlag="X" ApproachName="RNPX" />
-        <STAR Name="KEWI2Y" OpDataFlag="Y" ApproachName="RNPY" />
-        <STAR Name="TOTY4W" OpDataFlag="W" ApproachName="RNPW" />
+        <STAR Name="KEWI2X" OpDataFlag="X" ApproachName="RNP-ARX" />
+        <STAR Name="KEWI2Y" OpDataFlag="Y" ApproachName="RNP-ARY" />
+        <STAR Name="TOTY4W" OpDataFlag="W" ApproachName="RNP-ARW" />
       </Runway>
       <Runway Name="33V" DataRunway="33">
         <STAR Name="KEWI2V" />
@@ -220,15 +220,15 @@
         <SID Name="CLIFT2" />
         <SID Name="MK2" Default="True" />
         <SID Name="POONA2" />
-        <STAR Name="DAGSI1" ApproachName="GNSSZ" />
-        <STAR Name="WELKE1" ApproachName="GNSSZ" />
+        <STAR Name="DAGSI1" ApproachName="RNPZ" />
+        <STAR Name="WELKE1" ApproachName="RNPZ" />
       </Runway>
       <Runway Name="32" DataRunway="32">
         <SID Name="CLIFT2" />
         <SID Name="MK2" Default="True" />
         <SID Name="POONA2" />
-        <STAR Name="DAGSI1" ApproachName="GNSSZ" />
-        <STAR Name="WELKE1" ApproachName="GNSSZ" />
+        <STAR Name="DAGSI1" ApproachName="RNPZ" />
+        <STAR Name="WELKE1" ApproachName="RNPZ" />
       </Runway>
     </Airport>
     <Airport Name="YBOK">
@@ -253,16 +253,16 @@
         <SID Name="BUDGI2" />
         <SID Name="RK3" Default="True" />
         <SID Name="TARES3" />
-        <STAR Name="ABVAS1" ApproachName="GNSSZ" />
-        <STAR Name="DADBO1" ApproachName="GNSSZ" />
+        <STAR Name="ABVAS1" ApproachName="RNPZ" />
+        <STAR Name="DADBO1" ApproachName="RNPZ" />
       </Runway>
       <Runway Name="22" DataRunway="22" />
       <Runway Name="33" DataRunway="33">
         <SID Name="BUDGI2" />
         <SID Name="RK3" Default="True" />
         <SID Name="TARES3" />
-        <STAR Name="ABVAS1" ApproachName="GNSSZ" />
-        <STAR Name="DADBO1" ApproachName="GNSSZ" />
+        <STAR Name="ABVAS1" ApproachName="RNPZ" />
+        <STAR Name="DADBO1" ApproachName="RNPZ" />
       </Runway>
     </Airport>
     <Airport Name="YBRM">
@@ -277,20 +277,20 @@
       <Runway Name="13" DataRunway="13">
         <SID Name="MOOLO1" />
         <SID Name="TAPET1" />
-        <STAR Name="ITID1W" OpDataFlag="W" ApproachName="RNPW" />
-        <STAR Name="ITID1Z" OpDataFlag="Z" ApproachName="GNSSZ" />
-        <STAR Name="REBE2Z" OpDataFlag="Z" ApproachName="GNSSZ" />
-        <STAR Name="SEBV1Z" OpDataFlag="Z" ApproachName="GNSSZ" />
+        <STAR Name="ITID1W" OpDataFlag="W" ApproachName="RNP-ARW" />
+        <STAR Name="ITID1Z" OpDataFlag="Z" ApproachName="RNPZ" />
+        <STAR Name="REBE2Z" OpDataFlag="Z" ApproachName="RNPZ" />
+        <STAR Name="SEBV1Z" OpDataFlag="Z" ApproachName="RNPZ" />
       </Runway>
       <Runway Name="31" DataRunway="31">
         <SID Name="MOOLO1" />
         <SID Name="TAPET1" />
-        <STAR Name="ITID1W" OpDataFlag="W" ApproachName="RNPW" />
-        <STAR Name="ITID1Z" OpDataFlag="Z" ApproachName="GNSSZ" />
-        <STAR Name="REBE2X" OpDataFlag="X" ApproachName="RNPX" />
-        <STAR Name="REBE2Z" OpDataFlag="Z" ApproachName="GNSSZ" />
-        <STAR Name="SEBV1X" OpDataFlag="X" ApproachName="RNPX" />
-        <STAR Name="SEBV1Z" OpDataFlag="Z" ApproachName="GNSSZ" />
+        <STAR Name="ITID1W" OpDataFlag="W" ApproachName="RNP-ARW" />
+        <STAR Name="ITID1Z" OpDataFlag="Z" ApproachName="RNPZ" />
+        <STAR Name="REBE2X" OpDataFlag="X" ApproachName="RNP-ARX" />
+        <STAR Name="REBE2Z" OpDataFlag="Z" ApproachName="RNPZ" />
+        <STAR Name="SEBV1X" OpDataFlag="X" ApproachName="RNP-ARX" />
+        <STAR Name="SEBV1Z" OpDataFlag="Z" ApproachName="RNPZ" />
       </Runway>
     </Airport>
     <Airport Name="YBTL">
@@ -304,12 +304,12 @@
         <SID Name="TLE3" Default="True" />
         <SID Name="TLN4" Default="True" />
         <SID Name="WALTA1" />
-        <STAR Name="IBUX1A" ApproachName="GNSSZ" />
-        <STAR Name="PORO1A" ApproachName="GNSSZ" />
-        <STAR Name="PORO1P" OpDataFlag="P" ApproachName="RNPP" />
-        <STAR Name="SPAR1A" ApproachName="GNSSZ" />
-        <STAR Name="VOMP1A" ApproachName="GNSSZ" />
-        <STAR Name="VOMP1P" OpDataFlag="P" ApproachName="RNPP" />
+        <STAR Name="IBUX1A" ApproachName="RNPZ" />
+        <STAR Name="PORO1A" ApproachName="RNPZ" />
+        <STAR Name="PORO1P" OpDataFlag="P" ApproachName="RNP-ARP" />
+        <STAR Name="SPAR1A" ApproachName="RNPZ" />
+        <STAR Name="VOMP1A" ApproachName="RNPZ" />
+        <STAR Name="VOMP1P" OpDataFlag="P" ApproachName="RNP-ARP" />
       </Runway>
       <Runway Name="07" DataRunway="07" />
       <Runway Name="19" DataRunway="19">
@@ -322,13 +322,13 @@
         <SID Name="RURTO1" />
         <SID Name="SWIFT1" />
         <SID Name="WALTA1" />
-        <STAR Name="IBUX1Z" OpDataFlag="Z" ApproachName="GNSSZ" />
+        <STAR Name="IBUX1Z" OpDataFlag="Z" ApproachName="RNPZ" />
         <STAR Name="PORO1B" OpDataFlag="B" ApproachName="VOR" />
-        <STAR Name="PORO1P" OpDataFlag="P" ApproachName="RNPP" />
-        <STAR Name="PORO1Z" OpDataFlag="Z" ApproachName="GNSSZ" />
+        <STAR Name="PORO1P" OpDataFlag="P" ApproachName="RNP-ARP" />
+        <STAR Name="PORO1Z" OpDataFlag="Z" ApproachName="RNPZ" />
         <STAR Name="VOMP1B" OpDataFlag="B" ApproachName="VOR" />
-        <STAR Name="VOMP1P" OpDataFlag="P" ApproachName="RNPP" />
-        <STAR Name="VOMP1Z" OpDataFlag="Z" ApproachName="GNSSZ" />
+        <STAR Name="VOMP1P" OpDataFlag="P" ApproachName="RNP-ARP" />
+        <STAR Name="VOMP1Z" OpDataFlag="Z" ApproachName="RNPZ" />
       </Runway>
       <Runway Name="25" DataRunway="25" />
     </Airport>
@@ -356,14 +356,14 @@
       <Runway Name="07" DataRunway="07">
         <SID Name="DUGGI1" />
         <SID Name="UGVER1" />
-        <STAR Name="ARRAN1" ApproachName="GNSSZ" />
-        <STAR Name="VEGRU1" ApproachName="GNSSZ" />
+        <STAR Name="ARRAN1" ApproachName="RNPZ" />
+        <STAR Name="VEGRU1" ApproachName="RNPZ" />
       </Runway>
       <Runway Name="25" DataRunway="25">
         <SID Name="DUGGI1" />
         <SID Name="UGVER1" />
-        <STAR Name="ARRAN1" ApproachName="GNSSZ" />
-        <STAR Name="VEGRU1" ApproachName="GNSSZ" />
+        <STAR Name="ARRAN1" ApproachName="RNPZ" />
+        <STAR Name="VEGRU1" ApproachName="RNPZ" />
       </Runway>
     </Airport>
     <Airport Name="YMEN">
@@ -400,18 +400,18 @@
         <SID Name="KANLI3" Type="NonJet" />
         <SID Name="LATUM2" Type="Jet" />
         <SID Name="LAVOP1" />
-        <STAR Name="IPLE5A" ApproachName="GNSSZ" />
-        <STAR Name="IPLE5W" OpDataFlag="W" ApproachName="RNPW" />
-        <STAR Name="MORG1A" ApproachName="GNSSZ" />
+        <STAR Name="IPLE5A" ApproachName="RNPZ" />
+        <STAR Name="IPLE5W" OpDataFlag="W" ApproachName="RNP-ARW" />
+        <STAR Name="MORG1A" ApproachName="RNPZ" />
       </Runway>
       <Runway Name="30" DataRunway="30">
         <SID Name="CLARK2" />
         <SID Name="KANLI3" Type="NonJet" />
         <SID Name="LATUM2" Type="Jet" />
-        <STAR Name="IPLE5A" ApproachName="GNSSZ" />
-        <STAR Name="IPLE5W" OpDataFlag="W" ApproachName="RNPW" />
-        <STAR Name="MORG1A" ApproachName="GNSSZ" />
-        <STAR Name="MORG1W" OpDataFlag="W" ApproachName="RNPW" />
+        <STAR Name="IPLE5A" ApproachName="RNPZ" />
+        <STAR Name="IPLE5W" OpDataFlag="W" ApproachName="RNP-ARW" />
+        <STAR Name="MORG1A" ApproachName="RNPZ" />
+        <STAR Name="MORG1W" OpDataFlag="W" ApproachName="RNP-ARW" />
       </Runway>
       <Runway Name="12V" DataRunway="12">
         <STAR Name="IPLE5V" />
@@ -468,12 +468,12 @@
     <Airport Name="YMML">
       <Runway Name="09" DataRunway="09">
         <SID Name="ML6" Default="True" />
-        <STAR Name="ARBE6A" ApproachName="GNSSZ" />
-        <STAR Name="BOYS7A" ApproachName="GNSSZ" />
-        <STAR Name="LIZI8A" ApproachName="GNSSZ" />
-        <STAR Name="PORT6A" ApproachName="GNSSZ" />
-        <STAR Name="WARE7A" ApproachName="GNSSZ" />
-        <STAR Name="WEND9A" ApproachName="GNSSZ" />
+        <STAR Name="ARBE6A" ApproachName="RNPZ" />
+        <STAR Name="BOYS7A" ApproachName="RNPZ" />
+        <STAR Name="LIZI8A" ApproachName="RNPZ" />
+        <STAR Name="PORT6A" ApproachName="RNPZ" />
+        <STAR Name="WARE7A" ApproachName="RNPZ" />
+        <STAR Name="WEND9A" ApproachName="RNPZ" />
       </Runway>
       <Runway Name="16" DataRunway="16">
         <SID Name="CORRS9" Type="Jet" />
@@ -487,13 +487,13 @@
         <SID Name="NEVIS7" Type="Jet" />
         <SID Name="NONIX3" Type="Jet" />
         <SID Name="SUNTI3" Type="Jet" />
-        <STAR Name="ARBE6A" ApproachName="GNSSZ" />
-        <STAR Name="BOYS7A" ApproachName="GNSSZ" />
-        <STAR Name="LIZI8A" ApproachName="GNSSZ" />
-        <STAR Name="WARE7A" ApproachName="GNSSZ" />
-        <STAR Name="WARE7M" OpDataFlag="M" ApproachName="RNPM" />
-        <STAR Name="WEND9A" ApproachName="GNSSZ" />
-        <STAR Name="WEND9P" OpDataFlag="P" ApproachName="RNPP" />
+        <STAR Name="ARBE6A" ApproachName="RNPZ" />
+        <STAR Name="BOYS7A" ApproachName="RNPZ" />
+        <STAR Name="LIZI8A" ApproachName="RNPZ" />
+        <STAR Name="WARE7A" ApproachName="RNPZ" />
+        <STAR Name="WARE7M" OpDataFlag="M" ApproachName="RNP-ARM" />
+        <STAR Name="WEND9A" ApproachName="RNPZ" />
+        <STAR Name="WEND9P" OpDataFlag="P" ApproachName="RNP-ARP" />
       </Runway>
       <Runway Name="27" DataRunway="27">
         <SID Name="CORRS9" Type="Jet" />
@@ -506,11 +506,11 @@
         <SID Name="NEVIS7" Type="Jet" />
         <SID Name="NONIX3" Type="Jet" />
         <SID Name="SUNTI3" Type="Jet" />
-        <STAR Name="ARBE6A" ApproachName="GNSSZ" />
-        <STAR Name="BOYS7A" ApproachName="GNSSZ" />
-        <STAR Name="LIZI8A" ApproachName="GNSSZ" />
-        <STAR Name="WARE7A" ApproachName="GNSSZ" />
-        <STAR Name="WEND9A" ApproachName="GNSSZ" />
+        <STAR Name="ARBE6A" ApproachName="RNPZ" />
+        <STAR Name="BOYS7A" ApproachName="RNPZ" />
+        <STAR Name="LIZI8A" ApproachName="RNPZ" />
+        <STAR Name="WARE7A" ApproachName="RNPZ" />
+        <STAR Name="WEND9A" ApproachName="RNPZ" />
       </Runway>
       <Runway Name="34" DataRunway="34">
         <SID Name="CORRS9" Type="Jet" />
@@ -523,12 +523,12 @@
         <SID Name="NEVIS7" Type="Jet" />
         <SID Name="NONIX3" Type="Jet" />
         <SID Name="SUNTI3" Type="Jet" />
-        <STAR Name="ARBE6A" ApproachName="GNSSZ" />
-        <STAR Name="BOYS7A" ApproachName="GNSSZ" />
-        <STAR Name="LIZI8A" ApproachName="GNSSZ" />
-        <STAR Name="PORT6A" ApproachName="GNSSZ" />
-        <STAR Name="WARE7A" ApproachName="GNSSZ" />
-        <STAR Name="WEND9A" ApproachName="GNSSZ" />
+        <STAR Name="ARBE6A" ApproachName="RNPZ" />
+        <STAR Name="BOYS7A" ApproachName="RNPZ" />
+        <STAR Name="LIZI8A" ApproachName="RNPZ" />
+        <STAR Name="PORT6A" ApproachName="RNPZ" />
+        <STAR Name="WARE7A" ApproachName="RNPZ" />
+        <STAR Name="WEND9A" ApproachName="RNPZ" />
       </Runway>
       <Runway Name="34V" DataRunway="34">
         <STAR Name="BOYS7V" />
@@ -545,16 +545,16 @@
         <SID Name="ORBUN5" Type="Jet" />
         <SID Name="PANKI3" Type="Jet" />
         <SID Name="SEDAN2" Type="Jet" />
-        <STAR Name="ALEX3X" OpDataFlag="X" ApproachName="RNPX" />
-        <STAR Name="ALEX3Z" OpDataFlag="Z" ApproachName="GNSSZ" />
+        <STAR Name="ALEX3X" OpDataFlag="X" ApproachName="RNP-ARX" />
+        <STAR Name="ALEX3Z" OpDataFlag="Z" ApproachName="RNPZ" />
         <STAR Name="ATPIP3" Type="NonJet" />
-        <STAR Name="BLAC3X" OpDataFlag="X" ApproachName="RNPX" />
-        <STAR Name="BLAC3Z" OpDataFlag="Z" ApproachName="GNSSZ" />
-        <STAR Name="RIKA8W" OpDataFlag="W" ApproachName="RNPW" />
-        <STAR Name="RIKA8Z" OpDataFlag="Z" ApproachName="GNSSZ" />
+        <STAR Name="BLAC3X" OpDataFlag="X" ApproachName="RNP-ARX" />
+        <STAR Name="BLAC3Z" OpDataFlag="Z" ApproachName="RNPZ" />
+        <STAR Name="RIKA8W" OpDataFlag="W" ApproachName="RNP-ARW" />
+        <STAR Name="RIKA8Z" OpDataFlag="Z" ApproachName="RNPZ" />
         <STAR Name="RUSSL3" Type="NonJet" />
-        <STAR Name="SALT3W" OpDataFlag="W" ApproachName="RNPW" />
-        <STAR Name="SALT3Z" OpDataFlag="Z" ApproachName="GNSSZ" />
+        <STAR Name="SALT3W" OpDataFlag="W" ApproachName="RNP-ARW" />
+        <STAR Name="SALT3Z" OpDataFlag="Z" ApproachName="RNPZ" />
         <STAR Name="SURGN3" Type="NonJet" />
       </Runway>
       <Runway Name="12" DataRunway="12">
@@ -571,17 +571,17 @@
         <SID Name="PANKI3" Type="Jet" />
         <SID Name="SEDAN2" Type="Jet" />
         <STAR Name="ATPIP3" Type="NonJet" />
-        <STAR Name="BLAC3A" ApproachName="GNSSZ" />
-        <STAR Name="BLAC3Z" OpDataFlag="Z" ApproachName="GNSSZ" />
-        <STAR Name="DRIN9A" ApproachName="GNSSZ" />
-        <STAR Name="DRIN9Z" OpDataFlag="Z" ApproachName="GNSSZ" />
-        <STAR Name="RAYN2A" ApproachName="GNSSZ" />
-        <STAR Name="RAYN2Z" OpDataFlag="Z" ApproachName="GNSSZ" />
-        <STAR Name="RIKA8A" ApproachName="GNSSZ" />
-        <STAR Name="RIKA8Z" OpDataFlag="Z" ApproachName="GNSSZ" />
+        <STAR Name="BLAC3A" ApproachName="RNPZ" />
+        <STAR Name="BLAC3Z" OpDataFlag="Z" ApproachName="RNPZ" />
+        <STAR Name="DRIN9A" ApproachName="RNPZ" />
+        <STAR Name="DRIN9Z" OpDataFlag="Z" ApproachName="RNPZ" />
+        <STAR Name="RAYN2A" ApproachName="RNPZ" />
+        <STAR Name="RAYN2Z" OpDataFlag="Z" ApproachName="RNPZ" />
+        <STAR Name="RIKA8A" ApproachName="RNPZ" />
+        <STAR Name="RIKA8Z" OpDataFlag="Z" ApproachName="RNPZ" />
         <STAR Name="RUSSL3" Type="NonJet" />
-        <STAR Name="SALT3A" ApproachName="GNSSZ" />
-        <STAR Name="SALT3Z" OpDataFlag="Z" ApproachName="GNSSZ" />
+        <STAR Name="SALT3A" ApproachName="RNPZ" />
+        <STAR Name="SALT3Z" OpDataFlag="Z" ApproachName="RNPZ" />
         <STAR Name="SURGN3" Type="NonJet" />
       </Runway>
       <Runway Name="30" DataRunway="30">
@@ -625,16 +625,16 @@
         <SID Name="PALGA7" Type="Jet" />
         <SID Name="RUSKA6" Type="NonJet" />
         <SID Name="VANDI6" Type="NonJet" />
-        <STAR Name="DONY8A" ApproachName="RNPU" />
-        <STAR Name="DONY8U" OpDataFlag="U" ApproachName="RNPU" />
-        <STAR Name="GATO8A" ApproachName="RNPU" />
-        <STAR Name="GATO8U" OpDataFlag="U" ApproachName="RNPU" />
-        <STAR Name="VEGP6A" ApproachName="RNPU" />
-        <STAR Name="VEGP6P" OpDataFlag="P" ApproachName="RNPP" />
-        <STAR Name="VEGP6U" OpDataFlag="U" ApproachName="RNPU" />
-        <STAR Name="WANG1A" ApproachName="RNPU" />
-        <STAR Name="WANG1P" OpDataFlag="P" ApproachName="RNPP" />
-        <STAR Name="WANG1U" OpDataFlag="U" ApproachName="RNPU" />
+        <STAR Name="DONY9A" ApproachName="RNPX" />
+        <STAR Name="DONY9U" OpDataFlag="U" ApproachName="RNP-ARU" />
+        <STAR Name="GATO9A" ApproachName="RNPX" />
+        <STAR Name="GATO9U" OpDataFlag="U" ApproachName="RNP-ARU" />
+        <STAR Name="VEGP7A" ApproachName="RNPX" />
+        <STAR Name="VEGP7P" OpDataFlag="P" ApproachName="RNP-ARP" />
+        <STAR Name="VEGP7U" OpDataFlag="U" ApproachName="RNP-ARU" />
+        <STAR Name="WANG2A" ApproachName="RNPX" />
+        <STAR Name="WANG2P" OpDataFlag="P" ApproachName="RNP-ARP" />
+        <STAR Name="WANG2U" OpDataFlag="U" ApproachName="RNP-ARU" />
       </Runway>
       <Runway Name="18" DataRunway="18">
         <SID Name="DN7" Default="True" />
@@ -649,15 +649,15 @@
         <SID Name="PALGA7" Type="Jet" />
         <SID Name="RUSKA6" Type="NonJet" />
         <SID Name="VANDI6" Type="NonJet" />
-        <STAR Name="DONY8A" ApproachName="LOC" />
-        <STAR Name="DONY8U" OpDataFlag="U" ApproachName="RNPU" />
-        <STAR Name="GATO8A" ApproachName="LOC" />
-        <STAR Name="GATO8U" OpDataFlag="U" ApproachName="RNPU" />
-        <STAR Name="VEGP6A" ApproachName="LOC" />
-        <STAR Name="VEGP6U" OpDataFlag="U" ApproachName="RNPU" />
-        <STAR Name="WANG1A" ApproachName="LOC" />
-        <STAR Name="WANG1P" OpDataFlag="P" ApproachName="RNPP" />
-        <STAR Name="WANG1U" OpDataFlag="U" ApproachName="RNPU" />
+        <STAR Name="DONY9A" ApproachName="LOC" />
+        <STAR Name="DONY9U" OpDataFlag="U" ApproachName="RNP-ARU" />
+        <STAR Name="GATO9A" ApproachName="LOC" />
+        <STAR Name="GATO9U" OpDataFlag="U" ApproachName="RNP-ARU" />
+        <STAR Name="VEGP7A" ApproachName="LOC" />
+        <STAR Name="VEGP7U" OpDataFlag="U" ApproachName="RNP-ARU" />
+        <STAR Name="WANG2A" ApproachName="LOC" />
+        <STAR Name="WANG2P" OpDataFlag="P" ApproachName="RNP-ARP" />
+        <STAR Name="WANG2U" OpDataFlag="U" ApproachName="RNP-ARU" />
       </Runway>
       <Runway Name="36" DataRunway="36">
         <SID Name="DN7" />
@@ -777,19 +777,19 @@
         <SID Name="RAVON3" Type="NonJet" />
         <SID Name="SOLUS3" />
         <SID Name="YNRV2" Type="Jet" />
-        <STAR Name="BEVL5A" ApproachName="GNSSZ" />
-        <STAR Name="BEVL5X" OpDataFlag="X" ApproachName="RNPX" />
-        <STAR Name="CONI4A" Type="NonJet" ApproachName="GNSSZ" />
-        <STAR Name="CONI4X" Type="NonJet" OpDataFlag="X" ApproachName="RNPX" />
-        <STAR Name="DAYL4A" Type="NonJet" ApproachName="GNSSZ" />
-        <STAR Name="DAYL4X" Type="NonJet" OpDataFlag="X" ApproachName="RNPX" />
-        <STAR Name="GREN5A" Type="NonJet" ApproachName="GNSSZ" />
-        <STAR Name="GREN5X" Type="NonJet" OpDataFlag="X" ApproachName="RNPX" />
-        <STAR Name="JULI5A" ApproachName="GNSSZ" />
-        <STAR Name="JULI5X" OpDataFlag="X" ApproachName="RNPX" />
-        <STAR Name="SOLU2A" ApproachName="GNSSZ" />
-        <STAR Name="SOLU2X" OpDataFlag="X" ApproachName="RNPX" />
-        <STAR Name="WAVE3A" ApproachName="GNSSZ" />
+        <STAR Name="BEVL5A" ApproachName="RNPZ" />
+        <STAR Name="BEVL5X" OpDataFlag="X" ApproachName="RNP-ARX" />
+        <STAR Name="CONI4A" Type="NonJet" ApproachName="RNPZ" />
+        <STAR Name="CONI4X" Type="NonJet" OpDataFlag="X" ApproachName="RNP-ARX" />
+        <STAR Name="DAYL4A" Type="NonJet" ApproachName="RNPZ" />
+        <STAR Name="DAYL4X" Type="NonJet" OpDataFlag="X" ApproachName="RNP-ARX" />
+        <STAR Name="GREN5A" Type="NonJet" ApproachName="RNPZ" />
+        <STAR Name="GREN5X" Type="NonJet" OpDataFlag="X" ApproachName="RNP-ARX" />
+        <STAR Name="JULI5A" ApproachName="RNPZ" />
+        <STAR Name="JULI5X" OpDataFlag="X" ApproachName="RNP-ARX" />
+        <STAR Name="SOLU2A" ApproachName="RNPZ" />
+        <STAR Name="SOLU2X" OpDataFlag="X" ApproachName="RNP-ARX" />
+        <STAR Name="WAVE3A" ApproachName="RNPZ" />
       </Runway>
       <Runway Name="06" DataRunway="06">
         <SID Name="AMANA2" Type="Jet" />
@@ -806,13 +806,13 @@
         <SID Name="RAVON3" Type="NonJet" />
         <SID Name="SOLUS3" />
         <SID Name="YNRV2" Type="Jet" />
-        <STAR Name="BEVL5A" ApproachName="GNSSZ" />
-        <STAR Name="CONI4A" Type="NonJet" ApproachName="GNSSZ" />
-        <STAR Name="DAYL4A" Type="NonJet" ApproachName="GNSSZ" />
-        <STAR Name="GREN5A" Type="NonJet" ApproachName="GNSSZ" />
-        <STAR Name="JULI5A" ApproachName="GNSSZ" />
-        <STAR Name="SOLU2A" ApproachName="GNSSZ" />
-        <STAR Name="WAVE3A" ApproachName="GNSSZ" />
+        <STAR Name="BEVL5A" ApproachName="RNPZ" />
+        <STAR Name="CONI4A" Type="NonJet" ApproachName="RNPZ" />
+        <STAR Name="DAYL4A" Type="NonJet" ApproachName="RNPZ" />
+        <STAR Name="GREN5A" Type="NonJet" ApproachName="RNPZ" />
+        <STAR Name="JULI5A" ApproachName="RNPZ" />
+        <STAR Name="SOLU2A" ApproachName="RNPZ" />
+        <STAR Name="WAVE3A" ApproachName="RNPZ" />
       </Runway>
       <Runway Name="21" DataRunway="21">
         <SID Name="AMANA2" Type="Jet" />
@@ -829,12 +829,12 @@
         <SID Name="RAVON3" Type="NonJet" />
         <SID Name="SOLUS3" />
         <SID Name="YNRV2" Type="Jet" />
-        <STAR Name="BEVL5A" ApproachName="GNSSZ" />
-        <STAR Name="CONI4A" Type="NonJet" ApproachName="GNSSZ" />
-        <STAR Name="GREN5A" Type="NonJet" ApproachName="GNSSZ" />
-        <STAR Name="JULI5A" ApproachName="GNSSZ" />
+        <STAR Name="BEVL5A" ApproachName="RNPZ" />
+        <STAR Name="CONI4A" Type="NonJet" ApproachName="RNPZ" />
+        <STAR Name="GREN5A" Type="NonJet" ApproachName="RNPZ" />
+        <STAR Name="JULI5A" ApproachName="RNPZ" />
         <STAR Name="SOLU2A" />
-        <STAR Name="WAVE3A" ApproachName="GNSSZ" />
+        <STAR Name="WAVE3A" ApproachName="RNPZ" />
       </Runway>
       <Runway Name="24" DataRunway="24">
         <SID Name="AMANA2" Type="Jet" />
@@ -851,10 +851,10 @@
         <SID Name="RAVON3" Type="NonJet" />
         <SID Name="SOLUS3" />
         <SID Name="YNRV2" Type="Jet" />
-        <STAR Name="BEVL5A" ApproachName="GNSSZ" />
-        <STAR Name="CONI4A" Type="NonJet" ApproachName="GNSSZ" />
-        <STAR Name="GREN5A" Type="NonJet" ApproachName="GNSSZ" />
-        <STAR Name="JULI5A" ApproachName="GNSSZ" />
+        <STAR Name="BEVL5A" ApproachName="RNPZ" />
+        <STAR Name="CONI4A" Type="NonJet" ApproachName="RNPZ" />
+        <STAR Name="GREN5A" Type="NonJet" ApproachName="RNPZ" />
+        <STAR Name="JULI5A" ApproachName="RNPZ" />
         <STAR Name="SOLU2A" />
         <STAR Name="WAVE3A" />
       </Runway>
@@ -927,13 +927,14 @@
         <SID Name="NONUP8" Type="Jet" />
         <SID Name="TANTA2" Type="Jet" />
         <SID Name="WG1" Type="Jet" />
-        <STAR Name="AVBE4A" ApproachName="RNPW" />
-        <STAR Name="BUNG3A" ApproachName="RNPW" />
-        <STAR Name="MAND2A" ApproachName="RNPW" />
-        <STAR Name="MAND2X" OpDataFlag="X" ApproachName="RNPX" />
-        <STAR Name="RAZI6A" ApproachName="RNPW" />
-        <STAR Name="RAZI6W" OpDataFlag="W" ApproachName="RNPW" />
-        <STAR Name="RAZI6Y" OpDataFlag="Y" ApproachName="RNPY" />
+        <STAR Name="AVBE4A" ApproachName="RNP-ARW" />
+        <STAR Name="BUNG4A" ApproachName="RNP-ARW" />
+        <STAR Name="BUNG4Y" Type="NonJet" OpDataFlag="Y" ApproachName="RNP-ARY" />
+        <STAR Name="MAND2A" ApproachName="RNP-ARW" />
+        <STAR Name="MAND2X" OpDataFlag="X" ApproachName="RNP-ARX" />
+        <STAR Name="RAZI6A" ApproachName="RNP-ARW" />
+        <STAR Name="RAZI6W" OpDataFlag="W" ApproachName="RNP-ARW" />
+        <STAR Name="RAZI6Y" OpDataFlag="Y" ApproachName="RNP-ARY" />
       </Runway>
       <Runway Name="30" DataRunway="30" />
       <Runway Name="35" DataRunway="35">
@@ -946,19 +947,21 @@
         <SID Name="NONUP8" Type="Jet" />
         <SID Name="TANTA2" Type="Jet" />
         <SID Name="WG1" Type="Jet" />
-        <STAR Name="AVBE4A" ApproachName="GNSSZ" />
-        <STAR Name="BUNG3A" ApproachName="GNSSZ" />
-        <STAR Name="POLI8A" ApproachName="GNSSZ" />
-        <STAR Name="POLI8X" OpDataFlag="X" ApproachName="RNPX" />
-        <STAR Name="RAZI6A" ApproachName="GNSSZ" />
-        <STAR Name="RAZI6W" OpDataFlag="W" ApproachName="RNPW" />
-        <STAR Name="RAZI6Y" OpDataFlag="Y" ApproachName="RNPY" />
+        <STAR Name="AVBE4A" ApproachName="RNPZ" />
+        <STAR Name="BUNG4A" ApproachName="RNPZ" />
+        <STAR Name="BUNG4W" Type="NonJet" OpDataFlag="W" ApproachName="RNP-ARW" />
+        <STAR Name="BUNG4Y" Type="NonJet" OpDataFlag="Y" ApproachName="RNP-ARY" />
+        <STAR Name="POLI8A" ApproachName="RNPZ" />
+        <STAR Name="POLI8X" OpDataFlag="X" ApproachName="RNP-ARX" />
+        <STAR Name="RAZI6A" ApproachName="RNPZ" />
+        <STAR Name="RAZI6W" OpDataFlag="W" ApproachName="RNP-ARW" />
+        <STAR Name="RAZI6Y" OpDataFlag="Y" ApproachName="RNP-ARY" />
       </Runway>
       <Runway Name="30V" DataRunway="30">
-        <STAR Name="BUNG3V" />
+        <STAR Name="BUNG4V" />
       </Runway>
       <Runway Name="35V" DataRunway="35">
-        <STAR Name="BUNG3V" />
+        <STAR Name="BUNG4V" />
         <STAR Name="RAZI6V" />
       </Runway>
     </Airport>
@@ -1015,7 +1018,7 @@
         <SID Name="KAMPI5" />
         <SID Name="SY2" Default="True" />
         <STAR Name="BORE3A" />
-        <STAR Name="BORE3P" OpDataFlag="P" ApproachName="GNSSZ" />
+        <STAR Name="BORE3P" OpDataFlag="P" ApproachName="RNPZ" />
         <STAR Name="MARLN5" />
         <STAR Name="MEPIL3" Type="NonJet" />
         <STAR Name="ODALE7" Type="NonJet" />
@@ -1024,7 +1027,7 @@
       <Runway Name="25" DataRunway="25">
         <SID Name="SY2" Default="True" />
         <STAR Name="BORE3A" />
-        <STAR Name="MARLN5" ApproachName="GNSSZ" />
+        <STAR Name="MARLN5" ApproachName="RNPZ" />
         <STAR Name="MEPIL3" Type="NonJet" />
         <STAR Name="ODALE7" Type="NonJet" />
         <STAR Name="RIVET3" />
@@ -16508,42 +16511,42 @@ BOFOR
       <Route Runway="23">SURGN/GRIGS/AD VOR</Route>
       <Route Runway="30">SURGN/GRIGS/AD VOR</Route>
     </STAR>
-    <STAR Name="DONY8A" Airport="YPDN" Runways="11,29">
+    <STAR Name="DONY9A" Airport="YPDN" Runways="11,29">
       <Route Runway="11">DONYA/SUDAG/ENBAB/SADAR/NASUX</Route>
       <Route Runway="29">DONYA/SUDAG/IDLUD/EPDAM/WOKKI/DAKTI/NEILO/LAPAR</Route>
     </STAR>
-    <STAR Name="DONY8U" Airport="YPDN" Runways="11,29">
+    <STAR Name="DONY9U" Airport="YPDN" Runways="11,29">
       <Route Runway="11">DONYA/SUDAG/ENBAB/SADAR/NASUX</Route>
       <Route Runway="29">DONYA/SUDAG/IDLUD/EPDAM/WOKKI/DAKTI/NEILO/LAPAR</Route>
     </STAR>
-    <STAR Name="GATO8A" Airport="YPDN" Runways="11,29">
+    <STAR Name="GATO9A" Airport="YPDN" Runways="11,29">
       <Route Runway="11">GATOR/KOOLI/VIKUV/ELGUM/NASUX</Route>
       <Route Runway="29">GATOR/BIDSA/SARRE/LAPAR</Route>
     </STAR>
-    <STAR Name="GATO8U" Airport="YPDN" Runways="11,29">
+    <STAR Name="GATO9U" Airport="YPDN" Runways="11,29">
       <Route Runway="11">GATOR/KOOLI/VIKUV/ELGUM/NASUX</Route>
       <Route Runway="29">GATOR/BIDSA/SARRE/LAPAR</Route>
     </STAR>
-    <STAR Name="VEGP6A" Airport="YPDN" Runways="11,29">
+    <STAR Name="VEGP7A" Airport="YPDN" Runways="11,29">
       <Route Runway="11">VEGPU/ITTSA/OLTEG/UPROX/KITTY/GIVEN/ALLOT/NASUX</Route>
       <Route Runway="29">VEGPU/ITTSA/SARRE/LAPAR</Route>
     </STAR>
-    <STAR Name="VEGP6P" Airport="YPDN" Runways="11">
+    <STAR Name="VEGP7P" Airport="YPDN" Runways="11">
       <Route Runway="11">VEGPU/ITTSA/OLTEG/UPROX/KITTY</Route>
     </STAR>
-    <STAR Name="VEGP6U" Airport="YPDN" Runways="11,29">
+    <STAR Name="VEGP7U" Airport="YPDN" Runways="11,29">
       <Route Runway="11">VEGPU/ITTSA/OLTEG/UPROX/KITTY/GIVEN/ALLOT/NASUX</Route>
       <Route Runway="29">VEGPU/ITTSA/SARRE/LAPAR</Route>
     </STAR>
-    <STAR Name="WANG1A" Airport="YPDN" Runways="11,29">
+    <STAR Name="WANG2A" Airport="YPDN" Runways="11,29">
       <Route Runway="11">WANGI/ANONA/KIGOS/KINGS/GIVEN/ALLOT/NASUX</Route>
       <Route Runway="29">WANGI/ANONA/KIGOS/KINGS/KITTY/NOONA/SARRE/LAPAR</Route>
     </STAR>
-    <STAR Name="WANG1P" Airport="YPDN" Runways="11,29">
+    <STAR Name="WANG2P" Airport="YPDN" Runways="11,29">
       <Route Runway="11">WANGI/ANONA/KIGOS/KINGS/UPSEN</Route>
       <Route Runway="29">WANGI/ANONA/KITTY</Route>
     </STAR>
-    <STAR Name="WANG1U" Airport="YPDN" Runways="11,29">
+    <STAR Name="WANG2U" Airport="YPDN" Runways="11,29">
       <Route Runway="11">WANGI/ANONA/KIGOS/KINGS/GIVEN/ALLOT/NASUX</Route>
       <Route Runway="29">WANGI/ANONA/KITTY/NOONA/SARRE/LAPAR</Route>
     </STAR>
@@ -16696,13 +16699,20 @@ BOFOR
       <Route Runway="17">AVBEG/GOONY/TALAG</Route>
       <Route Runway="35">AVBEG/LANYO/HONEY/DALEY/MENZI</Route>
     </STAR>
-    <STAR Name="BUNG3A" Airport="YSCB" Runways="17,35">
+    <STAR Name="BUNG4A" Airport="YSCB" Runways="17,35">
       <Route Runway="17">BUNGO/GEORG/GOONY/TALAG</Route>
       <Route Runway="35">BUNGO/HIPPO/FOXLO/GIBIL/MENZI</Route>
     </STAR>
-    <STAR Name="BUNG3V" Airport="YSCB" Runways="30,35">
+    <STAR Name="BUNG4V" Airport="YSCB" Runways="30,35">
       <Route Runway="30">BUNGO/ENDOR</Route>
       <Route Runway="35">BUNGO/HIPPO/PILOS</Route>
+    </STAR>
+    <STAR Name="BUNG4W" Airport="YSCB" Runways="35">
+      <Route Runway="35">BUNGO/HIPPO/FOXLO</Route>
+    </STAR>
+    <STAR Name="BUNG4Y" Airport="YSCB" Runways="17,35">
+      <Route Runway="17">BUNGO/GEORG/SAPIT</Route>
+      <Route Runway="35">BUNGO/HIPPO/BIBRU</Route>
     </STAR>
     <STAR Name="MAND2A" Airport="YSCB" Runways="17">
       <Transition Name="ARRAN">ARRAN/NONUP</Transition>
@@ -16789,65 +16799,59 @@ BOFOR
       <Route Runway="34L">RIVET/BIGEM/TAMMI/BOOGI/DUDOK/NASHO</Route>
       <Route Runway="34R">RIVET/BIGEM/TAMMI/BOOGI/DUDOK/NASHO</Route>
     </STAR>
-    <Approach Name="GNSSZ" Airport="YBBN" Runway="01L">
+    <Approach Name="RNPZ" Airport="YBBN" Runway="01L">
       <Transition Name="TANIK">TANIK</Transition>
       <Route>AKTOB/LUTSI/BN01L</Route>
     </Approach>
-    <Approach Name="GNSSZ" Airport="YBBN" Runway="01R">
+    <Approach Name="RNPZ" Airport="YBBN" Runway="01R">
       <Transition Name="GLENN">GLENN</Transition>
       <Route>NOMEV/GOGEX/BN01R</Route>
     </Approach>
-    <Approach Name="GNSSZ" Airport="YBBN" Runway="19L">
+    <Approach Name="RNPZ" Airport="YBBN" Runway="19L">
       <Transition Name="BETSO">BETSO</Transition>
       <Route>PIKON/OGATU/BN19L</Route>
     </Approach>
-    <Approach Name="GNSSZ" Airport="YBBN" Runway="19R">
+    <Approach Name="RNPZ" Airport="YBBN" Runway="19R">
       <Transition Name="OSOKO">OSOKO</Transition>
       <Route>OKVIS/SAKBO/BN19R</Route>
     </Approach>
-    <Approach Name="RNPM" Airport="YBBN" Runway="01R">
+    <Approach Name="RNP-ARM" Airport="YBBN" Runway="01R">
       <Route>BIPUD/BN505/BN515/BN01R</Route>
     </Approach>
-    <Approach Name="RNPX" Airport="YBBN" Runway="01L">
+    <Approach Name="RNP-ARX" Airport="YBBN" Runway="01L">
       <Transition Name="RUSVA">RUSVA</Transition>
       <Route>BN500/BN510/BN520/BN01L</Route>
     </Approach>
-    <Approach Name="RNPX" Airport="YBBN" Runway="01R">
+    <Approach Name="RNP-ARX" Airport="YBBN" Runway="01R">
       <Transition Name="SORVA">SORVA</Transition>
       <Route>BN525/BN535/BN545/BN01R</Route>
     </Approach>
-    <Approach Name="RNPX" Airport="YBBN" Runway="19L">
+    <Approach Name="RNP-ARX" Airport="YBBN" Runway="19L">
       <Transition Name="ATSEP">ATSEP</Transition>
       <Route>BN405/BN415/BN425/BN19L</Route>
     </Approach>
-    <Approach Name="RNPX" Airport="YBBN" Runway="19R">
+    <Approach Name="RNP-ARX" Airport="YBBN" Runway="19R">
       <Transition Name="LUVNA">LUVNA</Transition>
       <Route>BN400/BN411/BN421/BN19R</Route>
     </Approach>
-    <Approach Name="GNSSZ" Airport="YBCG" Runway="14">
+    <Approach Name="RNPZ" Airport="YBCG" Runway="14">
       <Transition Name="KEGAN">KEGAN</Transition>
       <Transition Name="OOLNC">OOLNC</Transition>
       <Route>OOLNI/OOLNF/CG14T</Route>
     </Approach>
-    <Approach Name="GNSSZ" Airport="YBCG" Runway="32">
+    <Approach Name="RNPZ" Airport="YBCG" Runway="32">
       <Transition Name="FIKUL">FIKUL</Transition>
       <Transition Name="OOLSA">OOLSA</Transition>
       <Transition Name="OOLSC">OOLSC</Transition>
       <Route>OOLSI/OOLSF/CG32T</Route>
     </Approach>
-    <Approach Name="RNPY" Airport="YBCG" Runway="14">
+    <Approach Name="RNP-ARY" Airport="YBCG" Runway="14">
       <Transition Name="KERRI">KERRI</Transition>
       <Route>CG045/-28.093209+153.567099/-28.082610+153.554675/-28.075254+153.539563/-28.071598+153.522809/-28.071582+153.508653/CG004/CG332/CG14T</Route>
     </Approach>
-    <Approach Name="RNPY" Airport="YBCG" Runway="32">
+    <Approach Name="RNP-ARY" Airport="YBCG" Runway="32">
       <Transition Name="ATKEN">ATKEN</Transition>
       <Route>CG421/CG422/CG440/CG32T</Route>
-    </Approach>
-    <Approach Name="GNSSZ" Airport="YBCS" Runway="15">
-      <Transition Name="ATOSU">ATOSU</Transition>
-      <Transition Name="GUNRO">GUNRO</Transition>
-      <Transition Name="PULAX">PULAX</Transition>
-      <Route>CNSNI/CNSNF/CNSNM</Route>
     </Approach>
     <Approach Name="LOC" Airport="YBCS" Runway="15">
       <Transition Name="GUNRO">GUNRO</Transition>
@@ -16858,24 +16862,30 @@ BOFOR
     <Approach Name="LOC" Airport="YBCS" Runway="33">
       <Route>HENDO/CS33T</Route>
     </Approach>
-    <Approach Name="RNPW" Airport="YBCS" Runway="15">
+    <Approach Name="RNPZ" Airport="YBCS" Runway="15">
+      <Transition Name="ATOSU">ATOSU</Transition>
+      <Transition Name="GUNRO">GUNRO</Transition>
+      <Transition Name="PULAX">PULAX</Transition>
+      <Route>CNSNI/CNSNF/CNSNM</Route>
+    </Approach>
+    <Approach Name="RNP-ARW" Airport="YBCS" Runway="15">
       <Transition Name="EPGAG">EPGAG</Transition>
       <Route>CS401/CS403/CS405/CS407/CS15T</Route>
     </Approach>
-    <Approach Name="RNPW" Airport="YBCS" Runway="33">
+    <Approach Name="RNP-ARW" Airport="YBCS" Runway="33">
       <Transition Name="LEBAD">LEBAD/CS510</Transition>
       <Route>CS511/CS512/CS513/CS540/CS541/CS33T</Route>
     </Approach>
-    <Approach Name="RNPX" Airport="YBCS" Runway="15">
+    <Approach Name="RNP-ARX" Airport="YBCS" Runway="15">
       <Transition Name="GUNRO">GUNRO/CS400</Transition>
       <Transition Name="TODEG">TODEG/CS402/CS404</Transition>
       <Route>CS405/CS407/CS15T</Route>
     </Approach>
-    <Approach Name="RNPX" Airport="YBCS" Runway="33">
+    <Approach Name="RNP-ARX" Airport="YBCS" Runway="33">
       <Transition Name="LAVUP">LAVUP</Transition>
       <Route>CS530/CS531/CS532/CS541/CS33T</Route>
     </Approach>
-    <Approach Name="RNPY" Airport="YBCS" Runway="33">
+    <Approach Name="RNP-ARY" Airport="YBCS" Runway="33">
       <Transition Name="BASIL">BASIL/CS520/-17.155845+146.002876/-17.168933+145.984733/-17.177051+145.963609/-17.179666+145.941003/-17.176599+145.918461/-17.171497+145.904391/CS521/CS523</Transition>
       <Transition Name="HENDO">HENDO/CS522/CS523</Transition>
       <Route>CS540/CS541/CS33T</Route>
@@ -16885,68 +16895,68 @@ BOFOR
       <Transition Name="UPOLO">UPOLO</Transition>
       <Route>SUNNY/BENJI/CS15T</Route>
     </Approach>
-    <Approach Name="GNSSZ" Airport="YBMK" Runway="14">
+    <Approach Name="RNPZ" Airport="YBMK" Runway="14">
       <Transition Name="BMKNA">BMKNA</Transition>
       <Transition Name="LEDUS">LEDUS</Transition>
       <Transition Name="LUMVA">LUMVA</Transition>
       <Route>BMKNI/BMKNF/BMKNM</Route>
     </Approach>
-    <Approach Name="GNSSZ" Airport="YBMK" Runway="32">
+    <Approach Name="RNPZ" Airport="YBMK" Runway="32">
       <Transition Name="BAVAM">BAVAM</Transition>
       <Transition Name="BMKSJ">BMKSJ</Transition>
       <Transition Name="BURNO">BURNO</Transition>
       <Route>BMKSI/BMKSF/BMKSM</Route>
     </Approach>
-    <Approach Name="GNSSZ" Airport="YBRK" Runway="15">
+    <Approach Name="RNPZ" Airport="YBRK" Runway="15">
       <Transition Name="BASOB">BASOB</Transition>
       <Transition Name="BRKNC">BRKNC</Transition>
       <Transition Name="GOKUN">GOKUN</Transition>
       <Route>BRKNI/BRKNF/BRKNM</Route>
     </Approach>
-    <Approach Name="GNSSZ" Airport="YBRK" Runway="33">
+    <Approach Name="RNPZ" Airport="YBRK" Runway="33">
       <Transition Name="BRKSJ">BRKSJ</Transition>
       <Transition Name="LALIS">LALIS</Transition>
       <Transition Name="SARUS">SARUS</Transition>
       <Route>BRKSI/BRKSF/RK33T</Route>
     </Approach>
-    <Approach Name="GNSSZ" Airport="YBSU" Runway="13">
+    <Approach Name="RNPZ" Airport="YBSU" Runway="13">
       <Transition Name="OLTUD">OLTUD</Transition>
       <Transition Name="UPLOT">UPLOT</Transition>
       <Route>BSZNI/BSZNF/SU13T</Route>
     </Approach>
-    <Approach Name="GNSSZ" Airport="YBSU" Runway="31">
+    <Approach Name="RNPZ" Airport="YBSU" Runway="31">
       <Transition Name="BSZSC">BSZSC</Transition>
       <Transition Name="OVRUL">OVRUL</Transition>
       <Route>BSZSI/BSZSF/BSZSM</Route>
     </Approach>
-    <Approach Name="RNPW" Airport="YBSU" Runway="13">
+    <Approach Name="RNP-ARW" Airport="YBSU" Runway="13">
       <Transition Name="BUKRA">BUKRA/SU410</Transition>
       <Route>SU420/SU430/-26.453476+153.062010/-26.466064+153.036767/-26.488291+153.021952/-26.514170+153.021536/-26.526316+153.026978/SU440/SU13T</Route>
     </Approach>
-    <Approach Name="RNPW" Airport="YBSU" Runway="31">
+    <Approach Name="RNP-ARW" Airport="YBSU" Runway="31">
       <Transition Name="SAKAP">SAKAP</Transition>
       <Route>SU630/SU640/SU650/SU31T</Route>
     </Approach>
-    <Approach Name="RNPX" Airport="YBSU" Runway="31">
+    <Approach Name="RNP-ARX" Airport="YBSU" Runway="31">
       <Transition Name="IKISA">IKISA/SU615/-26.529486+153.316594/-26.567215+153.333031/-26.607290+153.326124/-26.638904+153.297721/-26.646632+153.283002/SU625</Transition>
       <Route>SU630/SU640/SU650/SU31T</Route>
     </Approach>
-    <Approach Name="GNSSZ" Airport="YBTL" Runway="01">
+    <Approach Name="RNPZ" Airport="YBTL" Runway="01">
       <Transition Name="FREDY">FREDY</Transition>
       <Transition Name="KIRAN">KIRAN</Transition>
       <Transition Name="SATCO">SATCO</Transition>
       <Route>GOTSI/TSVSF/TL01T</Route>
     </Approach>
-    <Approach Name="GNSSZ" Airport="YBTL" Runway="19">
+    <Approach Name="RNPZ" Airport="YBTL" Runway="19">
       <Transition Name="ADNOD">ADNOD</Transition>
       <Transition Name="LEBOT">LEBOT</Transition>
       <Transition Name="TSVNE">TSVNE</Transition>
       <Route>TSVNI/TSVNF/TSVNM</Route>
     </Approach>
-    <Approach Name="RNPP" Airport="YBTL" Runway="01">
+    <Approach Name="RNP-ARP" Airport="YBTL" Runway="01">
       <Route>GUGAN/KIRAN/TL788/TL780/ESDAM/TL01T</Route>
     </Approach>
-    <Approach Name="RNPP" Airport="YBTL" Runway="19">
+    <Approach Name="RNP-ARP" Airport="YBTL" Runway="19">
       <Route>VILUN/TL688/TL684/BIXAX/TL671/AGVIT/TL670/TL19T</Route>
     </Approach>
     <Approach Name="VOR" Airport="YBTL" Runway="19">
@@ -16957,146 +16967,152 @@ BOFOR
     <Approach Name="LOC" Airport="YMAV" Runway="18">
       <Route>TEMPL/IKANO/AV18T</Route>
     </Approach>
-    <Approach Name="GNSSZ" Airport="YMAY" Runway="07">
+    <Approach Name="RNPZ" Airport="YMAY" Runway="07">
       <Transition Name="RURLA">RURLA</Transition>
       <Transition Name="UPDUR">UPDUR</Transition>
       <Route>BUXAM/IGURI/AY07T</Route>
     </Approach>
-    <Approach Name="GNSSZ" Airport="YMAY" Runway="25">
+    <Approach Name="RNPZ" Airport="YMAY" Runway="25">
       <Transition Name="AB2EA">AB2EA</Transition>
       <Transition Name="BEMGI">BEMGI</Transition>
       <Transition Name="OLRUT">OLRUT</Transition>
       <Route>AB2EI/AB2EF/AY25T</Route>
     </Approach>
-    <Approach Name="GNSSZ" Airport="YMHB" Runway="12">
+    <Approach Name="RNPZ" Airport="YMHB" Runway="12">
       <Transition Name="BUSKA">BUSKA</Transition>
       <Transition Name="HBZWD">HBZWD</Transition>
       <Transition Name="HBZWG">HBZWG</Transition>
       <Route>HBZWI/HBZWF/HBZWM</Route>
     </Approach>
-    <Approach Name="GNSSZ" Airport="YMHB" Runway="30">
+    <Approach Name="RNPZ" Airport="YMHB" Runway="30">
       <Transition Name="HBTEB">HBTEB</Transition>
       <Transition Name="HBTEC">HBTEC</Transition>
       <Transition Name="PIDOS">PIDOS</Transition>
       <Route>HBTEI/HBTEF/HBTEM</Route>
     </Approach>
-    <Approach Name="RNPW" Airport="YMHB" Runway="12">
+    <Approach Name="RNP-ARW" Airport="YMHB" Runway="12">
       <Route>VETOR/HB410/-42.693819+147.432459/-42.709729+147.420420/-42.727463+147.414419/-42.745733+147.414869/-42.763296+147.421744/-42.777637+147.433270/HB420/HB12T</Route>
     </Approach>
-    <Approach Name="RNPW" Airport="YMHB" Runway="30">
+    <Approach Name="RNP-ARW" Airport="YMHB" Runway="30">
       <Route>BAVUR/HB510/-42.868736+147.667376/-42.878295+147.655323/-42.885236+147.640238/-42.889077+147.623212/-42.889556+147.605408/-42.886639+147.588044/-42.880619+147.572561/HB520/HB30T</Route>
     </Approach>
-    <Approach Name="GNSSZ" Airport="YMML" Runway="09">
+    <Approach Name="RNPZ" Airport="YMML" Runway="09">
       <Route>GUPUG/MMLWF/MMLWM</Route>
     </Approach>
-    <Approach Name="GNSSZ" Airport="YMML" Runway="16">
+    <Approach Name="RNPZ" Airport="YMML" Runway="16">
       <Transition Name="BELTA">BELTA</Transition>
       <Route>ANBEM/MMLNF/ML16T</Route>
     </Approach>
-    <Approach Name="GNSSZ" Airport="YMML" Runway="27">
+    <Approach Name="RNPZ" Airport="YMML" Runway="27">
       <Route>VISAS/MMLEF/MMLEM</Route>
     </Approach>
-    <Approach Name="GNSSZ" Airport="YMML" Runway="34">
+    <Approach Name="RNPZ" Airport="YMML" Runway="34">
       <Route>AKDEL/BOSGI/MMLSM</Route>
     </Approach>
-    <Approach Name="RNPM" Airport="YMML" Runway="16">
+    <Approach Name="RNP-ARM" Airport="YMML" Runway="16">
       <Route>LUVKA/AREXO/-37.548889+144.846667/-37.571389+144.829167/ML420/ML16T</Route>
     </Approach>
-    <Approach Name="RNPP" Airport="YMML" Runway="16">
+    <Approach Name="RNP-ARP" Airport="YMML" Runway="16">
       <Transition Name="EMSEK">EMSEK</Transition>
       <Route>SUSAK/-37.580928+144.952971/-37.557146+144.943081/-37.540510+144.919511/-37.535439+144.888614/-37.536462+144.879369/AREXO/-37.548889+144.846667/-37.571389+144.829167/ML420/ML16T</Route>
     </Approach>
-    <Approach Name="GNSSZ" Airport="YPAD" Runway="05">
+    <Approach Name="RNPZ" Airport="YPAD" Runway="05">
       <Transition Name="LUNGA">LUNGA</Transition>
       <Transition Name="PADSE">PADSE</Transition>
       <Transition Name="SIGUL">SIGUL</Transition>
       <Route>PADSI/PADSF/PADSM</Route>
     </Approach>
-    <Approach Name="GNSSZ" Airport="YPAD" Runway="23">
+    <Approach Name="RNPZ" Airport="YPAD" Runway="23">
       <Transition Name="GULLY">GULLY</Transition>
       <Transition Name="PADNJ">PADNJ</Transition>
       <Route>PADNI/PADNF/PADNM</Route>
     </Approach>
-    <Approach Name="RNPW" Airport="YPAD" Runway="05">
+    <Approach Name="RNP-ARW" Airport="YPAD" Runway="05">
       <Transition Name="SADMI">SADMI</Transition>
       <Route>AD010/AD030/AD05T</Route>
     </Approach>
-    <Approach Name="RNPX" Airport="YPAD" Runway="05">
+    <Approach Name="RNP-ARX" Airport="YPAD" Runway="05">
       <Transition Name="OGUGU">OGUGU</Transition>
       <Route>AD020/AD030/AD05T</Route>
     </Approach>
     <Approach Name="LOC" Airport="YPDN" Runway="29">
       <Route>LAPAR/TOROT/DN29T</Route>
     </Approach>
-    <Approach Name="RNPP" Airport="YPDN" Runway="11">
+    <Approach Name="RNPX" Airport="YPDN" Runway="11">
+      <Transition Name="KITTY">KITTY/TOSOB/DN412/-12.457634+130.746873/-12.445785+130.728423/-12.426499+130.718536/-12.404968+130.719849/-12.386964+130.732008/-12.377308+130.751753/-12.378339+130.772910/DN404</Transition>
+      <Transition Name="UPSEN">UPSEN/IGBOV/DN407/-12.427845+130.719496/-12.406284+130.720009/-12.387876+130.731518/-12.377552+130.750906/-12.378079+130.772981/-12.378420+130.774016/DN404</Transition>
+      <Transition Name="WOKKI">WOKKI/GUPOD/DN422/-12.299439+130.802345/-12.298133+130.780316/-12.307789+130.760577/-12.325794+130.748422/-12.347324+130.747109/-12.366610+130.756993/-12.378485+130.775426/-12.378693+130.776182/DN404</Transition>
+      <Route>NASUX/DN404</Route>
+    </Approach>
+    <Approach Name="RNP-ARP" Airport="YPDN" Runway="11">
       <Transition Name="KITTY">KITTY/TOSOB/DN412/-12.457633+130.746873/-12.452737+130.736928/-12.445472+130.728637/-12.436359+130.722556/-12.435797+130.722317</Transition>
       <Transition Name="UPSEN">UPSEN/IGBOV</Transition>
       <Route>DN407/-12.427845+130.719496/-12.406295+130.720395/-12.388086+130.732230/-12.378095+130.751800/-12.377467+130.766602/DN404/DN11T</Route>
     </Approach>
-    <Approach Name="RNPP" Airport="YPDN" Runway="29">
+    <Approach Name="RNP-ARP" Airport="YPDN" Runway="29">
       <Route>KITTY/GUMUR/DN448/-12.533533+130.973599/-12.535214+130.995618/-12.525893+131.015543/-12.508096+131.028022/-12.486591+131.029714/-12.467141+131.020166/-12.458983+131.010424/DN444/DN432/DN29T</Route>
     </Approach>
-    <Approach Name="RNPU" Airport="YPDN" Runway="11">
+    <Approach Name="RNP-ARU" Airport="YPDN" Runway="11">
       <Route>NASUX/DN404/DN11T</Route>
     </Approach>
-    <Approach Name="RNPU" Airport="YPDN" Runway="29">
+    <Approach Name="RNP-ARU" Airport="YPDN" Runway="29">
       <Route>LAPAR/DN432/DN29T</Route>
     </Approach>
-    <Approach Name="GNSSZ" Airport="YPPH" Runway="03">
+    <Approach Name="RNPZ" Airport="YPPH" Runway="03">
       <Route>TIMMY/PERSF/PH03T</Route>
     </Approach>
-    <Approach Name="GNSSZ" Airport="YPPH" Runway="06">
+    <Approach Name="RNPZ" Airport="YPPH" Runway="06">
       <Route>LENNY/PERWF/PH06T</Route>
     </Approach>
-    <Approach Name="GNSSZ" Airport="YPPH" Runway="21">
+    <Approach Name="RNPZ" Airport="YPPH" Runway="21">
       <Transition Name="KOORI">KOORI</Transition>
       <Transition Name="WOOFY">WOOFY/PERND</Transition>
       <Route>HAIGH/PERNF/PERNM</Route>
     </Approach>
-    <Approach Name="GNSSZ" Airport="YPPH" Runway="24">
+    <Approach Name="RNPZ" Airport="YPPH" Runway="24">
       <Route>KOORI/PEREF/PH24T</Route>
     </Approach>
-    <Approach Name="RNPX" Airport="YPPH" Runway="03">
+    <Approach Name="RNP-ARX" Airport="YPPH" Runway="03">
       <Route>KARGO/PH010/PH020/-32.048441+115.990231/-32.037745+115.965823/-32.018116+115.951029/-31.994846+115.949796/-31.993898+115.950092/PH030/PH03T</Route>
     </Approach>
-    <Approach Name="GNSSZ" Airport="YSCB" Runway="35">
+    <Approach Name="RNPZ" Airport="YSCB" Runway="35">
       <Transition Name="CBRSD">CBRSD</Transition>
       <Transition Name="CBRSG">CBRSG</Transition>
       <Transition Name="MENZI">MENZI</Transition>
       <Route>CBRSI/CBRSF/CBRSM</Route>
     </Approach>
-    <Approach Name="RNPW" Airport="YSCB" Runway="17">
+    <Approach Name="RNP-ARW" Airport="YSCB" Runway="17">
       <Route>TALAG/CB403/CB402/CB401/CB17T</Route>
     </Approach>
-    <Approach Name="RNPW" Airport="YSCB" Runway="35">
+    <Approach Name="RNP-ARW" Airport="YSCB" Runway="35">
       <Transition Name="FOXLO">FOXLO/CB430</Transition>
       <Route>CB431/CB432/CB444/CB445/CB446/CB35T</Route>
     </Approach>
-    <Approach Name="RNPX" Airport="YSCB" Runway="17">
+    <Approach Name="RNP-ARX" Airport="YSCB" Runway="17">
       <Route>VADMA/CB407/-35.103859+149.123798/-35.108852+149.160192/-35.128089+149.188646/-35.156384+149.201540/-35.171364+149.200871/CB402/CB401/CB17T</Route>
     </Approach>
-    <Approach Name="RNPX" Airport="YSCB" Runway="35">
+    <Approach Name="RNP-ARX" Airport="YSCB" Runway="35">
       <Transition Name="KALKA">KALKA</Transition>
       <Route>CB421/CB422/CB444/CB445/CB446/CB35T</Route>
     </Approach>
-    <Approach Name="RNPY" Airport="YSCB" Runway="17">
+    <Approach Name="RNP-ARY" Airport="YSCB" Runway="17">
       <Route>SAPIT/CB405/-35.112560+149.280925/-35.122876+149.252244/-35.138981+149.227801/-35.159707+149.209279/-35.171301+149.202773/CB402/CB401/CB17T</Route>
     </Approach>
-    <Approach Name="RNPY" Airport="YSCB" Runway="35">
+    <Approach Name="RNP-ARY" Airport="YSCB" Runway="35">
       <Transition Name="BIBRU">BIBRU/CB441</Transition>
       <Route>CB442/CB443/CB444/CB445/CB446/CB35T</Route>
     </Approach>
-    <Approach Name="GNSSZ" Airport="YSSY" Runway="16R">
+    <Approach Name="RNPZ" Airport="YSSY" Runway="16R">
       <Route>URDEN/SYDNF/SYDNM</Route>
     </Approach>
-    <Approach Name="GNSSZ" Airport="YSSY" Runway="25">
+    <Approach Name="RNPZ" Airport="YSSY" Runway="25">
       <Route>JELLI/SSYEF/SSYEM</Route>
     </Approach>
   </SIDSTARs>
   <Airports>
     <Airport ICAO="YAAL" FullName="Yarralin" Position="-162641.000+1305250.000" />
     <Airport ICAO="YAAP" FullName="Pinkenba/Airbus Australia Pacific" Position="-272608.000+1530644.000" />
-    <Airport ICAO="YABA" FullName="Albany" Position="-345636.000+1174832.000">
+    <Airport ICAO="YABA" FullName="Albany" Position="-345636.000+1174832.000" Elevation="233">
       <Runway Name="05" Position="-345649.660+1174820.920" />
       <Runway Name="23" Position="-345624.440+1174851.400" />
       <Runway Name="14" Position="-345624.370+1174812.420" />
@@ -17112,45 +17128,45 @@ BOFOR
     <Airport ICAO="YACR" FullName="Lotus Creek/Croydon" Position="-222824.000+1490922.000" />
     <Airport ICAO="YADA" FullName="Adavale" Position="-255342.000+1443412.000" />
     <Airport ICAO="YADE" FullName="Annandale" Position="-215636.000+1481702.000" />
-    <Airport ICAO="YADG" FullName="Aldinga" Position="-351720.000+1382936.000" />
+    <Airport ICAO="YADG" FullName="Aldinga" Position="-351720.000+1382936.000" Elevation="110" />
     <Airport ICAO="YADS" FullName="Alton Downs" Position="-263200.000+1391600.000" />
-    <Airport ICAO="YADY" FullName="Adaminaby" Position="-355954.000+1484748.000" />
-    <Airport ICAO="YAGD" FullName="Augustus Downs" Position="-183056.000+1395243.000" />
+    <Airport ICAO="YADY" FullName="Adaminaby" Position="-355954.000+1484748.000" Elevation="3350" />
+    <Airport ICAO="YAGD" FullName="Augustus Downs" Position="-183056.000+1395243.000" Elevation="150" />
     <Airport ICAO="YAGP" FullName="Angel Platform Oil Rig" Position="-192955.000+1163553.000" />
     <Airport ICAO="YAIN" FullName="Agincourt North" Position="-155852.000+1454913.000" />
     <Airport ICAO="YAIR" FullName="Moree/Beela" Position="-292347.000+1495213.000" />
     <Airport ICAO="YAIS" FullName="Agincourt South" Position="-160208.000+1455005.000" />
-    <Airport ICAO="YALA" FullName="Marla" Position="-272003.000+1333735.000" />
+    <Airport ICAO="YALA" FullName="Marla" Position="-272003.000+1333735.000" Elevation="1076" />
     <Airport ICAO="YALC" FullName="Alcoota Stn" Position="-225000.000+1342700.000" />
     <Airport ICAO="YALG" FullName="Adels Grove" Position="-184133.000+1383153.000" />
     <Airport ICAO="YALR" FullName="Aileron" Position="-223911.000+1332050.000" />
     <Airport ICAO="YALY" FullName="Alderley" Position="-222939.000+1393944.000" />
-    <Airport ICAO="YAMB" FullName="Amberley" Position="-273826.000+1524243.000">
+    <Airport ICAO="YAMB" FullName="Amberley" Position="-273826.000+1524243.000" Elevation="91">
       <Runway Name="04" Position="-273840.600+1524228.330" />
       <Runway Name="22" Position="-273811.720+1524313.490" />
       <Runway Name="15" Position="-273718.170+1524218.960" />
       <Runway Name="33" Position="-273850.440+1524259.270" />
     </Airport>
-    <Airport ICAO="YAMC" FullName="Aramac" Position="-225734.000+1451509.000" />
+    <Airport ICAO="YAMC" FullName="Aramac" Position="-225734.000+1451509.000" Elevation="760" />
     <Airport ICAO="YAML" FullName="Armraynald" Position="-175800.000+1394600.000" />
     <Airport ICAO="YAMM" FullName="Ammaroo" Position="-214418.000+1351430.000" />
     <Airport ICAO="YAMO" FullName="Belyando/Moray Downs" Position="-215637.000+1463800.000" />
-    <Airport ICAO="YAMT" FullName="Amata" Position="-260550.000+1311210.000" />
-    <Airport ICAO="YANG" FullName="West Angelas" Position="-230806.000+1184224.000">
+    <Airport ICAO="YAMT" FullName="Amata" Position="-260550.000+1311210.000" Elevation="2172" />
+    <Airport ICAO="YANG" FullName="West Angelas" Position="-230806.000+1184224.000" Elevation="2346">
       <Runway Name="04" Position="-230831.620+1184202.520" />
       <Runway Name="22" Position="-230749.750+1184248.700" />
     </Airport>
     <Airport ICAO="YANJ" FullName="Angatja" Position="-260600.000+1302400.000" />
-    <Airport ICAO="YANK" FullName="Anna Creek" Position="-285350.000+1361014.000" />
+    <Airport ICAO="YANK" FullName="Anna Creek" Position="-285350.000+1361014.000" Elevation="300" />
     <Airport ICAO="YANL" FullName="Anthony Lagoon" Position="-175832.000+1353217.000" />
     <Airport ICAO="YAOC" FullName="Dunmore/Opal Creek" Position="-274002.000+1505556.000" />
-    <Airport ICAO="YAOD" FullName="Aust Age Of Dinosaurs Museum" Position="-222848.000+1431057.000" />
-    <Airport ICAO="YAPH" FullName="Alpha" Position="-233846.000+1463501.000">
+    <Airport ICAO="YAOD" FullName="Aust Age Of Dinosaurs Museum" Position="-222848.000+1431057.000" Elevation="886" />
+    <Airport ICAO="YAPH" FullName="Alpha" Position="-233846.000+1463501.000" Elevation="1255">
       <Runway Name="18" Position="-233847.500+1463500.950" />
       <Runway Name="36" Position="-233934.430+1463453.820" />
     </Airport>
     <Airport ICAO="YAPO" FullName="Apollo Bay" Position="-384622.000+1433925.000" />
-    <Airport ICAO="YARA" FullName="Ararat" Position="-371834.000+1425919.000">
+    <Airport ICAO="YARA" FullName="Ararat" Position="-371834.000+1425919.000" Elevation="1008">
       <Runway Name="04" Position="-371839.510+1425912.880" />
       <Runway Name="22" Position="-371827.080+1425935.030" />
       <Runway Name="12" Position="-371829.380+1425907.300" />
@@ -17158,38 +17174,38 @@ BOFOR
     </Airport>
     <Airport ICAO="YARC" FullName="Archer River" Position="-132626.000+1425538.000" />
     <Airport ICAO="YARE" FullName="Redford/Redford Station" Position="-255019.000+1472444.000" />
-    <Airport ICAO="YARG" FullName="Argyle" Position="-163813.000+1282705.000">
+    <Airport ICAO="YARG" FullName="Argyle" Position="-163813.000+1282705.000" Elevation="522">
       <Runway Name="01" Position="-163841.110+1282647.770" />
       <Runway Name="19" Position="-163731.560+1282716.150" />
     </Airport>
-    <Airport ICAO="YARK" FullName="Arkaroola" Position="-302423.000+1392048.000" />
-    <Airport ICAO="YARM" FullName="Armidale" Position="-303141.000+1513702.000">
+    <Airport ICAO="YARK" FullName="Arkaroola" Position="-302423.000+1392048.000" Elevation="800" />
+    <Airport ICAO="YARM" FullName="Armidale" Position="-303141.000+1513702.000" Elevation="3556">
       <Runway Name="05" Position="-303158.650+1513632.860" />
       <Runway Name="23" Position="-303129.140+1513728.340" />
       <Runway Name="09" Position="-303126.640+1513637.380" />
       <Runway Name="27" Position="-303131.060+1513718.840" />
     </Airport>
     <Airport ICAO="YARR" FullName="Moranbah/Rugby Run" Position="-220754.000+1475336.000" />
-    <Airport ICAO="YARY" FullName="Arrabury" Position="-264126.000+1410250.000" />
+    <Airport ICAO="YARY" FullName="Arrabury" Position="-264126.000+1410250.000" Elevation="334" />
     <Airport ICAO="YASF" FullName="Ashford" Position="-291900.000+1510322.000" />
-    <Airport ICAO="YATN" FullName="Atherton" Position="-171543.000+1453052.000" />
+    <Airport ICAO="YATN" FullName="Atherton" Position="-171543.000+1453052.000" Elevation="2460" />
     <Airport ICAO="YAUA" FullName="Augathella" Position="-254518.000+1463512.000" />
-    <Airport ICAO="YAUG" FullName="Augusta" Position="-341948.000+1150924.000" />
-    <Airport ICAO="YAUR" FullName="Aurukun" Position="-132114.000+1414315.000">
+    <Airport ICAO="YAUG" FullName="Augusta" Position="-341948.000+1150924.000" Elevation="120" />
+    <Airport ICAO="YAUR" FullName="Aurukun" Position="-132114.000+1414315.000" Elevation="29">
       <Runway Name="16" Position="-132054.190+1414304.680" />
       <Runway Name="34" Position="-132132.920+1414318.620" />
     </Airport>
     <Airport ICAO="YAVD" FullName="Avon Downs" Position="-200221.000+1373118.000" />
     <Airport ICAO="YAVE" FullName="Avalon East" Position="-380142.000+1442931.000" />
     <Airport ICAO="YAXA" FullName="Alexandra" Position="-371112.000+1454252.000" />
-    <Airport ICAO="YAYE" FullName="Ayers Rock/Connellan" Position="-251110.000+1305832.000">
+    <Airport ICAO="YAYE" FullName="Ayers Rock/Connellan" Position="-251110.000+1305832.000" Elevation="1626">
       <Runway Name="13" Position="-251041.080+1305800.160" />
       <Runway Name="31" Position="-251134.800+1305911.760" />
     </Airport>
-    <Airport ICAO="YAYR" FullName="Ayr" Position="-193547.000+1471929.000" />
-    <Airport ICAO="YBAB" FullName="Baralaba" Position="-241112.000+1495042.000" />
-    <Airport ICAO="YBAD" FullName="Baradine" Position="-305718.000+1490530.000" />
-    <Airport ICAO="YBAF" FullName="Brisbane/Archerfield" Position="-273413.000+1530029.000">
+    <Airport ICAO="YAYR" FullName="Ayr" Position="-193547.000+1471929.000" Elevation="40" />
+    <Airport ICAO="YBAB" FullName="Baralaba" Position="-241112.000+1495042.000" Elevation="400" />
+    <Airport ICAO="YBAD" FullName="Baradine" Position="-305718.000+1490530.000" Elevation="990" />
+    <Airport ICAO="YBAF" FullName="Brisbane/Archerfield" Position="-273413.000+1530029.000" Elevation="65">
       <Runway Name="04L" Position="-273415.530+1530006.700" />
       <Runway Name="22R" Position="-273356.250+1530033.990" />
       <Runway Name="04R" Position="-273418.080+1530015.720" />
@@ -17201,57 +17217,57 @@ BOFOR
     </Airport>
     <Airport ICAO="YBAK" FullName="Brooklands Air Park" Position="-351944.000+1392606.000" />
     <Airport ICAO="YBAN" FullName="Mount Barnett" Position="-164414.000+1255432.000" />
-    <Airport ICAO="YBAR" FullName="Barcaldine" Position="-233355.000+1451824.000">
+    <Airport ICAO="YBAR" FullName="Barcaldine" Position="-233355.000+1451824.000" Elevation="880">
       <Runway Name="01" Position="-233422.040+1451800.130" />
       <Runway Name="19" Position="-233328.960+1451817.020" />
       <Runway Name="14" Position="-233339.980+1451815.760" />
       <Runway Name="32" Position="-233407.430+1451841.440" />
     </Airport>
-    <Airport ICAO="YBAS" FullName="Alice Springs" Position="-234830.000+1335403.000">
+    <Airport ICAO="YBAS" FullName="Alice Springs" Position="-234830.000+1335403.000" Elevation="1789">
       <Runway Name="12" Position="-234803.710+1335336.100" />
       <Runway Name="30" Position="-234843.630+1335450.500" />
       <Runway Name="17" Position="-234750.200+1335311.540" />
       <Runway Name="35" Position="-234826.940+1335312.770" />
     </Airport>
-    <Airport ICAO="YBAU" FullName="Badu Island" Position="-100900.000+1421027.000" />
+    <Airport ICAO="YBAU" FullName="Badu Island" Position="-100900.000+1421027.000" Elevation="45" />
     <Airport ICAO="YBAW" FullName="Barkly Downs" Position="-202945.000+1382829.000" />
     <Airport ICAO="YBBA" FullName="Barraba" Position="-302336.000+1503600.000" />
     <Airport ICAO="YBBC" FullName="Bamboo Creek" Position="-205700.000+1200900.000" />
-    <Airport ICAO="YBBF" FullName="Brooklet/Blueberry Fields" Position="-284423.000+1532914.000" />
-    <Airport ICAO="YBBN" FullName="Brisbane" Position="-272303.000+1530703.000">
+    <Airport ICAO="YBBF" FullName="Brooklet/Blueberry Fields" Position="-284423.000+1532914.000" Elevation="350" />
+    <Airport ICAO="YBBN" FullName="Brisbane" Position="-272303.000+1530703.000" Elevation="15">
       <Runway Name="01L" Position="-272259.050+1530624.490" />
       <Runway Name="19R" Position="-272123.560+1530719.090" />
       <Runway Name="01R" Position="-272410.070+1530705.590" />
       <Runway Name="19L" Position="-272228.790+1530803.500" />
     </Airport>
     <Airport ICAO="YBBS" FullName="Ban Ban Springs" Position="-132237.000+1312943.000" />
-    <Airport ICAO="YBBT" FullName="Boort" Position="-360814.000+1434314.000" />
-    <Airport ICAO="YBCG" FullName="Gold Coast" Position="-280952.000+1533017.000">
+    <Airport ICAO="YBBT" FullName="Boort" Position="-360814.000+1434314.000" Elevation="294" />
+    <Airport ICAO="YBCG" FullName="Gold Coast" Position="-280952.000+1533017.000" Elevation="21">
       <Runway Name="14" Position="-280923.440+1533002.540" />
       <Runway Name="32" Position="-281021.250+1533039.310" />
       <Runway Name="17" Position="-280951.680+1533024.310" />
       <Runway Name="35" Position="-281010.540+1533022.790" />
     </Airport>
     <Airport ICAO="YBCH" FullName="Beechworth" Position="-362340.000+1464148.000" />
-    <Airport ICAO="YBCK" FullName="Blackall" Position="-242540.000+1452543.000">
+    <Airport ICAO="YBCK" FullName="Blackall" Position="-242540.000+1452543.000" Elevation="928">
       <Runway Name="06" Position="-242606.130+1452515.630" />
       <Runway Name="24" Position="-242544.860+1452610.940" />
       <Runway Name="12" Position="-242514.370+1452511.730" />
       <Runway Name="30" Position="-242545.970+1452557.120" />
     </Airport>
-    <Airport ICAO="YBCM" FullName="Coominya" Position="-272330.000+1522742.000" />
-    <Airport ICAO="YBCS" FullName="Cairns/Cairns Intl" Position="-165309.000+1454519.000">
+    <Airport ICAO="YBCM" FullName="Coominya" Position="-272330.000+1522742.000" Elevation="330" />
+    <Airport ICAO="YBCS" FullName="Cairns/Cairns Intl" Position="-165309.000+1454519.000" Elevation="10">
       <Runway Name="15" Position="-165156.940+1454436.850" />
       <Runway Name="33" Position="-165331.090+1454519.410" />
     </Airport>
     <Airport ICAO="YBCT" FullName="Black Tip Whp" Position="-135300.000+1282900.000" />
-    <Airport ICAO="YBCV" FullName="Charleville" Position="-262448.000+1461545.000">
+    <Airport ICAO="YBCV" FullName="Charleville" Position="-262448.000+1461545.000" Elevation="1003">
       <Runway Name="12" Position="-262428.550+1461527.350" />
       <Runway Name="30" Position="-262504.770+1461604.850" />
       <Runway Name="18" Position="-262445.860+1461543.640" />
       <Runway Name="36" Position="-262520.520+1461542.320" />
     </Airport>
-    <Airport ICAO="YBDG" FullName="Bendigo" Position="-364421.000+1441947.000">
+    <Airport ICAO="YBDG" FullName="Bendigo" Position="-364421.000+1441947.000" Elevation="710">
       <Runway Name="05" Position="-364428.900+1441926.130" />
       <Runway Name="23" Position="-364416.740+1441953.140" />
       <Runway Name="17" Position="-364342.450+1441949.700" />
@@ -17259,81 +17275,81 @@ BOFOR
     </Airport>
     <Airport ICAO="YBDM" FullName="Old Bundemar" Position="-314818.000+1480948.000" />
     <Airport ICAO="YBDP" FullName="Bridport" Position="-410115.000+1472430.000" />
-    <Airport ICAO="YBDV" FullName="Birdsville" Position="-255351.000+1392051.000">
+    <Airport ICAO="YBDV" FullName="Birdsville" Position="-255351.000+1392051.000" Elevation="159">
       <Runway Name="03" Position="-255413.930+1392036.020" />
       <Runway Name="21" Position="-255353.970+1392054.410" />
       <Runway Name="14" Position="-255306.850+1392026.180" />
       <Runway Name="32" Position="-255355.000+1392058.430" />
     </Airport>
-    <Airport ICAO="YBEB" FullName="Bellburn" Position="-173241.000+1281818.000" />
-    <Airport ICAO="YBEE" FullName="Beverley Mine" Position="-301112.000+1393330.000" />
+    <Airport ICAO="YBEB" FullName="Bellburn" Position="-173241.000+1281818.000" Elevation="800" />
+    <Airport ICAO="YBEE" FullName="Beverley Mine" Position="-301112.000+1393330.000" Elevation="382" />
     <Airport ICAO="YBEG" FullName="Bening Field" Position="-193919.000+1461738.000" />
     <Airport ICAO="YBEI" FullName="Littlendy Desert/Beyondie" Position="-244437.000+1201925.000" />
-    <Airport ICAO="YBEO" FullName="Betoota" Position="-254142.000+1404412.000" />
+    <Airport ICAO="YBEO" FullName="Betoota" Position="-254142.000+1404412.000" Elevation="248" />
     <Airport ICAO="YBES" FullName="Beswick" Position="-143536.000+1330630.000" />
-    <Airport ICAO="YBEV" FullName="Beverley (Wa)" Position="-320729.000+1165700.000" />
+    <Airport ICAO="YBEV" FullName="Beverley (Wa)" Position="-320729.000+1165700.000" Elevation="720" />
     <Airport ICAO="YBFM" FullName="Beef Machine" Position="-334512.000+1222144.000" />
-    <Airport ICAO="YBFT" FullName="Beaufort" Position="-372940.000+1432548.000" />
-    <Airport ICAO="YBGD" FullName="Boolgeeda" Position="-223228.000+1171610.000">
+    <Airport ICAO="YBFT" FullName="Beaufort" Position="-372940.000+1432548.000" Elevation="1300" />
+    <Airport ICAO="YBGD" FullName="Boolgeeda" Position="-223228.000+1171610.000" Elevation="1870">
       <Runway Name="08" Position="-223228.420+1171531.810" />
       <Runway Name="26" Position="-223221.760+1171648.510" />
     </Airport>
-    <Airport ICAO="YBGO" FullName="Balgo Hill" Position="-200854.000+1275826.000">
+    <Airport ICAO="YBGO" FullName="Balgo Hill" Position="-200854.000+1275826.000" Elevation="1440">
       <Runway Name="15" Position="-200849.660+1275821.320" />
       <Runway Name="33" Position="-200933.440+1275851.740" />
     </Airport>
-    <Airport ICAO="YBGR" FullName="Bridgewater" Position="-363700.000+1435700.000" />
+    <Airport ICAO="YBGR" FullName="Bridgewater" Position="-363700.000+1435700.000" Elevation="500" />
     <Airport ICAO="YBGU" FullName="Bulga Underground" Position="-320430.000+1510620.000" />
-    <Airport ICAO="YBHI" FullName="Broken Hill" Position="-320005.000+1412818.000">
+    <Airport ICAO="YBHI" FullName="Broken Hill" Position="-320005.000+1412818.000" Elevation="959">
       <Runway Name="05" Position="-320032.470+1412739.320" />
       <Runway Name="23" Position="-315946.710+1412858.590" />
       <Runway Name="14" Position="-320013.790+1412759.560" />
       <Runway Name="32" Position="-320039.710+1412822.490" />
     </Airport>
-    <Airport ICAO="YBHL" FullName="Bindoon Hill" Position="-312025.000+1161118.000" />
-    <Airport ICAO="YBHM" FullName="Hamilton Island" Position="-202129.000+1485706.000">
+    <Airport ICAO="YBHL" FullName="Bindoon Hill" Position="-312025.000+1161118.000" Elevation="970" />
+    <Airport ICAO="YBHM" FullName="Hamilton Island" Position="-202129.000+1485706.000" Elevation="15">
       <Runway Name="14" Position="-202104.760+1485648.180" />
       <Runway Name="32" Position="-202149.010+1485723.690" />
     </Airport>
     <Airport ICAO="YBHN" FullName="Blenheim" Position="-273913.000+1521830.000" />
-    <Airport ICAO="YBIE" FullName="Bedourie" Position="-242046.000+1392737.000">
+    <Airport ICAO="YBIE" FullName="Bedourie" Position="-242046.000+1392737.000" Elevation="300">
       <Runway Name="14" Position="-242017.520+1392715.780" />
       <Runway Name="32" Position="-242106.230+1392751.670" />
     </Airport>
     <Airport ICAO="YBIK" FullName="Billa Kalina" Position="-295500.000+1361112.000" />
     <Airport ICAO="YBIN" FullName="Biggenden" Position="-253117.000+1520246.000" />
-    <Airport ICAO="YBIR" FullName="Birchip" Position="-355959.000+1425503.000">
+    <Airport ICAO="YBIR" FullName="Birchip" Position="-355959.000+1425503.000" Elevation="340">
       <Runway Name="04" Position="-360001.530+1425450.000" />
       <Runway Name="22" Position="-355941.800+1425520.690" />
       <Runway Name="09" Position="-360002.030+1425454.570" />
       <Runway Name="27" Position="-360004.290+1425515.310" />
     </Airport>
-    <Airport ICAO="YBIU" FullName="Ballidu" Position="-303536.000+1164648.000" />
-    <Airport ICAO="YBKE" FullName="Bourke" Position="-300219.000+1455707.000">
+    <Airport ICAO="YBIU" FullName="Ballidu" Position="-303536.000+1164648.000" Elevation="950" />
+    <Airport ICAO="YBKE" FullName="Bourke" Position="-300219.000+1455707.000" Elevation="352">
       <Runway Name="05" Position="-300241.670+1455612.710" />
       <Runway Name="23" Position="-300214.320+1455713.390" />
       <Runway Name="18" Position="-300156.570+1455725.530" />
       <Runway Name="36" Position="-300228.760+1455720.570" />
     </Airport>
-    <Airport ICAO="YBKT" FullName="Burketown" Position="-174455.000+1393204.000">
+    <Airport ICAO="YBKT" FullName="Burketown" Position="-174455.000+1393204.000" Elevation="21">
       <Runway Name="03" Position="-174518.520+1393151.540" />
       <Runway Name="21" Position="-174445.340+1393222.600" />
     </Airport>
-    <Airport ICAO="YBLA" FullName="Benalla" Position="-363315.000+1460033.000">
+    <Airport ICAO="YBLA" FullName="Benalla" Position="-363315.000+1460033.000" Elevation="569">
       <Runway Name="08" Position="-363306.980+1460024.260" />
       <Runway Name="26" Position="-363309.590+1460106.060" />
       <Runway Name="17" Position="-363259.010+1460016.650" />
       <Runway Name="35" Position="-363322.220+1460019.120" />
     </Airport>
-    <Airport ICAO="YBLC" FullName="Balcanoona" Position="-303204.000+1392016.000" />
-    <Airport ICAO="YBLL" FullName="Bollon" Position="-280313.000+1472842.000" />
-    <Airport ICAO="YBLN" FullName="Busselton" Position="-334114.000+1152401.000">
+    <Airport ICAO="YBLC" FullName="Balcanoona" Position="-303204.000+1392016.000" Elevation="474" />
+    <Airport ICAO="YBLL" FullName="Bollon" Position="-280313.000+1472842.000" Elevation="597" />
+    <Airport ICAO="YBLN" FullName="Busselton" Position="-334114.000+1152401.000" Elevation="56">
       <Runway Name="03" Position="-334150.340+1152346.950" />
       <Runway Name="21" Position="-334038.290+1152428.180" />
     </Airport>
     <Airport ICAO="YBLO" FullName="Bullio" Position="-342124.000+1501000.000" />
-    <Airport ICAO="YBLP" FullName="Blueter Park" Position="-191130.000+1462936.000" />
-    <Airport ICAO="YBLT" FullName="Ballarat" Position="-373042.000+1434728.000">
+    <Airport ICAO="YBLP" FullName="Blueter Park" Position="-191130.000+1462936.000" Elevation="110" />
+    <Airport ICAO="YBLT" FullName="Ballarat" Position="-373042.000+1434728.000" Elevation="1433">
       <Runway Name="05" Position="-373045.330+1434711.280" />
       <Runway Name="23" Position="-373025.930+1434756.680" />
       <Runway Name="13" Position="-373019.580+1434714.640" />
@@ -17341,41 +17357,41 @@ BOFOR
       <Runway Name="18" Position="-373024.880+1434741.760" />
       <Runway Name="36" Position="-373104.800+1434734.030" />
     </Airport>
-    <Airport ICAO="YBLU" FullName="Bellevue" Position="-273646.000+1203538.000">
+    <Airport ICAO="YBLU" FullName="Bellevue" Position="-273646.000+1203538.000" Elevation="1555">
       <Runway Name="01" Position="-273717.990+1203535.420" />
       <Runway Name="19" Position="-273613.530+1203544.420" />
     </Airport>
-    <Airport ICAO="YBMA" FullName="Mount Isa" Position="-203950.000+1392919.000">
+    <Airport ICAO="YBMA" FullName="Mount Isa" Position="-203950.000+1392919.000" Elevation="1121">
       <Runway Name="16" Position="-203918.150+1392909.170" />
       <Runway Name="34" Position="-204039.510+1392927.970" />
     </Airport>
     <Airport ICAO="YBMG" FullName="Bermagui" Position="-362535.000+1500434.000" />
-    <Airport ICAO="YBMI" FullName="Boomi" Position="-284344.000+1493544.000" />
-    <Airport ICAO="YBMK" FullName="Mackay" Position="-211017.000+1491047.000">
+    <Airport ICAO="YBMI" FullName="Boomi" Position="-284344.000+1493544.000" Elevation="580" />
+    <Airport ICAO="YBMK" FullName="Mackay" Position="-211017.000+1491047.000" Elevation="19">
       <Runway Name="14" Position="-210947.430+1491038.920" />
       <Runway Name="32" Position="-211041.900+1491115.630" />
     </Airport>
     <Airport ICAO="YBMR" FullName="Barmera" Position="-341454.000+1402819.000" />
-    <Airport ICAO="YBMY" FullName="Bamyili" Position="-143111.000+1325300.000" />
-    <Airport ICAO="YBNA" FullName="Ballina/Byron Gateway" Position="-285002.000+1533345.000">
+    <Airport ICAO="YBMY" FullName="Bamyili" Position="-143111.000+1325300.000" Elevation="706" />
+    <Airport ICAO="YBNA" FullName="Ballina/Byron Gateway" Position="-285002.000+1533345.000" Elevation="7">
       <Runway Name="06" Position="-285008.650+1533306.510" />
       <Runway Name="24" Position="-284951.110+1533413.700" />
     </Airport>
     <Airport ICAO="YBND" FullName="Bendick Murrell" Position="-341027.000+1482819.000" />
     <Airport ICAO="YBNE" FullName="Baal Bone Colliery" Position="-331611.000+1500331.000" />
-    <Airport ICAO="YBNR" FullName="Browns Range" Position="-185344.000+1285631.000" />
-    <Airport ICAO="YBNS" FullName="Bairnsdale" Position="-375315.000+1473404.000">
+    <Airport ICAO="YBNR" FullName="Browns Range" Position="-185344.000+1285631.000" Elevation="1466" />
+    <Airport ICAO="YBNS" FullName="Bairnsdale" Position="-375315.000+1473404.000" Elevation="165">
       <Runway Name="04" Position="-375325.200+1473351.580" />
       <Runway Name="22" Position="-375304.840+1473428.440" />
       <Runway Name="13" Position="-375300.240+1473356.760" />
       <Runway Name="31" Position="-375322.850+1473416.800" />
     </Airport>
     <Airport ICAO="YBNY" FullName="Brunchilly Stn" Position="-185209.000+1342740.000" />
-    <Airport ICAO="YBOA" FullName="Boonah" Position="-280103.000+1524036.000" />
+    <Airport ICAO="YBOA" FullName="Boonah" Position="-280103.000+1524036.000" Elevation="330" />
     <Airport ICAO="YBOB" FullName="Boorabin" Position="-311225.000+1201908.000" />
-    <Airport ICAO="YBOC" FullName="Booleroo Centre" Position="-325324.000+1382200.000" />
-    <Airport ICAO="YBOI" FullName="Boigu Island" Position="-091400.000+1421300.000" />
-    <Airport ICAO="YBOK" FullName="Oakey" Position="-272441.000+1514407.000">
+    <Airport ICAO="YBOC" FullName="Booleroo Centre" Position="-325324.000+1382200.000" Elevation="1372" />
+    <Airport ICAO="YBOI" FullName="Boigu Island" Position="-091400.000+1421300.000" Elevation="10" />
+    <Airport ICAO="YBOK" FullName="Oakey" Position="-272441.000+1514407.000" Elevation="1336">
       <Runway Name="05" Position="-272421.910+1514351.200" />
       <Runway Name="23" Position="-272404.820+1514418.440" />
       <Runway Name="09" Position="-272432.760+1514329.020" />
@@ -17383,89 +17399,89 @@ BOFOR
       <Runway Name="14" Position="-272409.610+1514413.540" />
       <Runway Name="32" Position="-272453.570+1514447.900" />
     </Airport>
-    <Airport ICAO="YBOM" FullName="Bombala" Position="-365418.000+1491100.000" />
+    <Airport ICAO="YBOM" FullName="Bombala" Position="-365418.000+1491100.000" Elevation="2480" />
     <Airport ICAO="YBOO" FullName="Bindoon" Position="-311632.000+1161545.000" />
-    <Airport ICAO="YBOR" FullName="Bordertown" Position="-361618.000+1404318.000" />
-    <Airport ICAO="YBOU" FullName="Boulia" Position="-225448.000+1395359.000">
+    <Airport ICAO="YBOR" FullName="Bordertown" Position="-361618.000+1404318.000" Elevation="265" />
+    <Airport ICAO="YBOU" FullName="Boulia" Position="-225448.000+1395359.000" Elevation="542">
       <Runway Name="14" Position="-225420.500+1395346.600" />
       <Runway Name="32" Position="-225511.000+1395419.100" />
     </Airport>
     <Airport ICAO="YBOV" FullName="Border Village" Position="-313811.000+1290039.000" />
     <Airport ICAO="YBPI" FullName="Brampton Island" Position="-204812.000+1491612.000" />
-    <Airport ICAO="YBPK" FullName="Batman Park Heliport" Position="-374920.000+1445724.000" />
-    <Airport ICAO="YBPN" FullName="Proserpine/Whitsunday Coast" Position="-202942.000+1483308.000">
+    <Airport ICAO="YBPK" FullName="Batman Park Heliport" Position="-374920.000+1445724.000" Elevation="10" />
+    <Airport ICAO="YBPN" FullName="Proserpine/Whitsunday Coast" Position="-202942.000+1483308.000" Elevation="82">
       <Runway Name="11" Position="-202925.760+1483239.910" />
       <Runway Name="29" Position="-202953.710+1483345.030" />
     </Airport>
     <Airport ICAO="YBRB" FullName="Browse Basin" Position="-135709.000+1231823.000" />
     <Airport ICAO="YBRI" FullName="Berri" Position="-341630.000+1403609.000" />
     <Airport ICAO="YBRJ" FullName="Burren Junction" Position="-300931.000+1485827.000" />
-    <Airport ICAO="YBRK" FullName="Rockhampton" Position="-232255.000+1502831.000">
+    <Airport ICAO="YBRK" FullName="Rockhampton" Position="-232255.000+1502831.000" Elevation="36">
       <Runway Name="04" Position="-232256.850+1502755.400" />
       <Runway Name="22" Position="-232240.970+1502817.720" />
       <Runway Name="15" Position="-232209.190+1502814.020" />
       <Runway Name="33" Position="-232326.450+1502848.420" />
     </Airport>
-    <Airport ICAO="YBRL" FullName="Borroloola" Position="-160431.000+1361808.000" />
-    <Airport ICAO="YBRM" FullName="Broome/Intl" Position="-175658.000+1221340.000">
+    <Airport ICAO="YBRL" FullName="Borroloola" Position="-160431.000+1361808.000" Elevation="55" />
+    <Airport ICAO="YBRM" FullName="Broome/Intl" Position="-175658.000+1221340.000" Elevation="57">
       <Runway Name="10" Position="-175645.530+1221300.780" />
       <Runway Name="28" Position="-175704.710+1221412.940" />
     </Airport>
-    <Airport ICAO="YBRN" FullName="Balranald" Position="-343725.000+1433442.000">
+    <Airport ICAO="YBRN" FullName="Balranald" Position="-343725.000+1433442.000" Elevation="210">
       <Runway Name="08" Position="-343718.770+1433432.930" />
       <Runway Name="26" Position="-343718.170+1433458.490" />
       <Runway Name="18" Position="-343710.230+1433439.910" />
       <Runway Name="36" Position="-343748.530+1433435.410" />
     </Airport>
-    <Airport ICAO="YBRS" FullName="Barwon Heads/Geelong" Position="-381529.000+1442539.000" />
+    <Airport ICAO="YBRS" FullName="Barwon Heads/Geelong" Position="-381529.000+1442539.000" Elevation="50" />
     <Airport ICAO="YBRU" FullName="Brunette Downs" Position="-183822.000+1355620.000" />
-    <Airport ICAO="YBRW" FullName="Brewarrina" Position="-295826.000+1464900.000">
+    <Airport ICAO="YBRW" FullName="Brewarrina" Position="-295826.000+1464900.000" Elevation="414">
       <Runway Name="03" Position="-295851.190+1464836.570" />
       <Runway Name="21" Position="-295814.630+1464906.650" />
     </Airport>
-    <Airport ICAO="YBRY" FullName="Barimunya" Position="-224026.000+1190958.000">
+    <Airport ICAO="YBRY" FullName="Barimunya" Position="-224026.000+1190958.000" Elevation="2082">
       <Runway Name="10" Position="-224020.480+1190927.230" />
       <Runway Name="28" Position="-224036.380+1191030.810" />
     </Airport>
-    <Airport ICAO="YBSG" FullName="Scherger (RAAF)" Position="-123726.000+1420514.000">
+    <Airport ICAO="YBSG" FullName="Scherger (RAAF)" Position="-123726.000+1420514.000" Elevation="145">
       <Runway Name="12" Position="-123656.200+1420433.770" />
       <Runway Name="30" Position="-123748.310+1420559.760" />
     </Airport>
-    <Airport ICAO="YBSL" FullName="Rowsley/Brooks Landing" Position="-374229.000+1442034.000" />
+    <Airport ICAO="YBSL" FullName="Rowsley/Brooks Landing" Position="-374229.000+1442034.000" Elevation="600" />
     <Airport ICAO="YBSM" FullName="Blossom Banks" Position="-194329.000+1502529.000" />
     <Airport ICAO="YBSO" FullName="Bulga Surface Operations" Position="-324053.000+1510729.000" />
     <Airport ICAO="YBSP" FullName="Bond Springs" Position="-233054.000+1335036.000" />
-    <Airport ICAO="YBSS" FullName="Bacchus Marsh" Position="-374400.000+1442520.000" />
+    <Airport ICAO="YBSS" FullName="Bacchus Marsh" Position="-374400.000+1442520.000" Elevation="520" />
     <Airport ICAO="YBST" FullName="Billabong Stn" Position="-334333.000+1473026.000" />
-    <Airport ICAO="YBSU" FullName="Sunshine Coast" Position="-263612.000+1530528.000">
+    <Airport ICAO="YBSU" FullName="Sunshine Coast" Position="-263612.000+1530528.000" Elevation="15">
       <Runway Name="13" Position="-263459.570+1530428.260" />
       <Runway Name="31" Position="-263602.620+1530522.370" />
     </Airport>
-    <Airport ICAO="YBTH" FullName="Bathurst" Position="-332434.000+1493907.000">
+    <Airport ICAO="YBTH" FullName="Bathurst" Position="-332434.000+1493907.000" Elevation="2435">
       <Runway Name="08" Position="-332424.110+1493857.380" />
       <Runway Name="26" Position="-332424.590+1493948.250" />
       <Runway Name="17" Position="-332402.800+1493902.540" />
       <Runway Name="35" Position="-332457.990+1493906.920" />
     </Airport>
-    <Airport ICAO="YBTI" FullName="Bathurst Island" Position="-114609.000+1303711.000">
+    <Airport ICAO="YBTI" FullName="Bathurst Island" Position="-114609.000+1303711.000" Elevation="67">
       <Runway Name="15" Position="-114531.230+1303643.950" />
       <Runway Name="33" Position="-114612.840+1303708.370" />
     </Airport>
-    <Airport ICAO="YBTL" FullName="Townsville/Townsville Intl" Position="-191509.000+1464555.000">
+    <Airport ICAO="YBTL" FullName="Townsville/Townsville Intl" Position="-191509.000+1464555.000" Elevation="18">
       <Runway Name="01" Position="-191529.900+1464553.000" />
       <Runway Name="19" Position="-191417.530+1464627.180" />
       <Runway Name="07" Position="-191520.910+1464519.960" />
       <Runway Name="25" Position="-191511.060+1464556.070" />
     </Airport>
     <Airport ICAO="YBTN" FullName="Barton Siding" Position="-303130.000+1323936.000" />
-    <Airport ICAO="YBTR" FullName="Blackwater" Position="-233611.000+1484825.000" />
-    <Airport ICAO="YBUD" FullName="Bundaberg" Position="-245414.000+1521907.000">
+    <Airport ICAO="YBTR" FullName="Blackwater" Position="-233611.000+1484825.000" Elevation="658" />
+    <Airport ICAO="YBUD" FullName="Bundaberg" Position="-245414.000+1521907.000" Elevation="107">
       <Runway Name="07" Position="-245422.880+1521849.660" />
       <Runway Name="25" Position="-245409.640+1521927.150" />
       <Runway Name="14" Position="-245350.270+1521902.110" />
       <Runway Name="32" Position="-245445.250+1521940.170" />
     </Airport>
-    <Airport ICAO="YBUN" FullName="Bunbury" Position="-332241.000+1154037.000">
+    <Airport ICAO="YBUN" FullName="Bunbury" Position="-332241.000+1154037.000" Elevation="53">
       <Runway Name="07" Position="-332249.960+1154020.760" />
       <Runway Name="25" Position="-332235.150+1154055.870" />
     </Airport>
@@ -17474,177 +17490,177 @@ BOFOR
     <Airport ICAO="YBWH" FullName="Blue Lagoon" Position="-134539.000+1415102.000" />
     <Airport ICAO="YBWL" FullName="Bramwell Station" Position="-120853.000+1423710.000" />
     <Airport ICAO="YBWM" FullName="Bulimba" Position="-165251.000+1432847.000" />
-    <Airport ICAO="YBWN" FullName="Bowen" Position="-200104.000+1481255.000">
+    <Airport ICAO="YBWN" FullName="Bowen" Position="-200104.000+1481255.000" Elevation="26">
       <Runway Name="04" Position="-200123.950+1481232.660" />
       <Runway Name="22" Position="-200057.040+1481304.440" />
       <Runway Name="12" Position="-200052.890+1481237.870" />
       <Runway Name="30" Position="-200109.710+1481303.290" />
     </Airport>
-    <Airport ICAO="YBWP" FullName="Weipa" Position="-124043.000+1415531.000">
+    <Airport ICAO="YBWP" FullName="Weipa" Position="-124043.000+1415531.000" Elevation="63">
       <Runway Name="12" Position="-124023.700+1415458.200" />
       <Runway Name="30" Position="-124053.840+1415543.280" />
     </Airport>
-    <Airport ICAO="YBWW" FullName="Brisbane West Wellcamp" Position="-273331.000+1514739.000">
+    <Airport ICAO="YBWW" FullName="Brisbane West Wellcamp" Position="-273331.000+1514739.000" Elevation="1509">
       <Runway Name="12" Position="-273255.510+1514704.190" />
       <Runway Name="30" Position="-273358.660+1514821.190" />
     </Airport>
-    <Airport ICAO="YBWX" FullName="Barrow Island" Position="-205152.000+1152422.000">
+    <Airport ICAO="YBWX" FullName="Barrow Island" Position="-205152.000+1152422.000" Elevation="26">
       <Runway Name="03" Position="-205208.280+1152409.460" />
       <Runway Name="21" Position="-205113.020+1152438.830" />
     </Airport>
-    <Airport ICAO="YBYI" FullName="Bruny Island" Position="-431406.000+1472247.000" />
-    <Airport ICAO="YBYL" FullName="Baryulgil" Position="-291259.000+1523654.000" />
+    <Airport ICAO="YBYI" FullName="Bruny Island" Position="-431406.000+1472247.000" Elevation="26" />
+    <Airport ICAO="YBYL" FullName="Baryulgil" Position="-291259.000+1523654.000" Elevation="398" />
     <Airport ICAO="YBYO" FullName="Brymaroo" Position="-271340.000+1513648.000" />
     <Airport ICAO="YBYU" FullName="Bayu Undan" Position="-110412.000+1263648.000" />
-    <Airport ICAO="YCAB" FullName="Caboolture" Position="-270437.000+1525913.000" />
-    <Airport ICAO="YCAG" FullName="Caiguna" Position="-321649.000+1252840.000" />
-    <Airport ICAO="YCAH" FullName="Coolah" Position="-314624.000+1493634.000">
+    <Airport ICAO="YCAB" FullName="Caboolture" Position="-270437.000+1525913.000" Elevation="40" />
+    <Airport ICAO="YCAG" FullName="Caiguna" Position="-321649.000+1252840.000" Elevation="287" />
+    <Airport ICAO="YCAH" FullName="Coolah" Position="-314624.000+1493634.000" Elevation="1654">
       <Runway Name="08" Position="-314625.660+1493634.240" />
       <Runway Name="26" Position="-314625.970+1493714.910" />
     </Airport>
     <Airport ICAO="YCAP" FullName="Capel" Position="-333543.000+1153418.000" />
-    <Airport ICAO="YCAR" FullName="Carnarvon" Position="-245250.000+1134020.000">
+    <Airport ICAO="YCAR" FullName="Carnarvon" Position="-245250.000+1134020.000" Elevation="13">
       <Runway Name="04" Position="-245310.630+1133951.640" />
       <Runway Name="22" Position="-245232.360+1134031.230" />
       <Runway Name="18" Position="-245243.440+1133958.760" />
       <Runway Name="36" Position="-245319.970+1133959.270" />
     </Airport>
-    <Airport ICAO="YCAS" FullName="Casino" Position="-285258.000+1530401.000" />
+    <Airport ICAO="YCAS" FullName="Casino" Position="-285258.000+1530401.000" Elevation="86" />
     <Airport ICAO="YCAV" FullName="Caravonica" Position="-165100.000+1454139.000" />
     <Airport ICAO="YCAX" FullName="Carrara" Position="-280000.000+1532200.000" />
-    <Airport ICAO="YCBA" FullName="Cobar" Position="-313218.000+1454738.000">
+    <Airport ICAO="YCBA" FullName="Cobar" Position="-313218.000+1454738.000" Elevation="724">
       <Runway Name="05" Position="-313229.540+1454714.030" />
       <Runway Name="23" Position="-313201.300+1454801.160" />
       <Runway Name="17" Position="-313217.140+1454741.410" />
       <Runway Name="35" Position="-313246.250+1454744.280" />
     </Airport>
-    <Airport ICAO="YCBB" FullName="Coonabarabran" Position="-311957.000+1491602.000">
+    <Airport ICAO="YCBB" FullName="Coonabarabran" Position="-311957.000+1491602.000" Elevation="2117">
       <Runway Name="01" Position="-312005.790+1491613.140" />
       <Runway Name="19" Position="-311947.540+1491625.200" />
       <Runway Name="11" Position="-311937.530+1491521.590" />
       <Runway Name="29" Position="-312004.350+1491609.900" />
     </Airport>
-    <Airport ICAO="YCBG" FullName="Hobart/Cambridge" Position="-424936.000+1472829.000" />
+    <Airport ICAO="YCBG" FullName="Hobart/Cambridge" Position="-424936.000+1472829.000" Elevation="67" />
     <Airport ICAO="YCBH" FullName="Cairns Base Hospital" Position="-165441.000+1454608.000" />
     <Airport ICAO="YCBL" FullName="Camballin" Position="-175910.000+1240952.000" />
-    <Airport ICAO="YCBP" FullName="Coober Pedy" Position="-290224.000+1344315.000">
+    <Airport ICAO="YCBP" FullName="Coober Pedy" Position="-290224.000+1344315.000" Elevation="745">
       <Runway Name="04" Position="-290239.620+1344251.710" />
       <Runway Name="22" Position="-290209.200+1344331.580" />
       <Runway Name="14" Position="-290211.230+1344315.560" />
       <Runway Name="32" Position="-290234.630+1344330.840" />
     </Airport>
-    <Airport ICAO="YCBR" FullName="Collarenebri" Position="-293119.000+1483456.000" />
+    <Airport ICAO="YCBR" FullName="Collarenebri" Position="-293119.000+1483456.000" Elevation="500" />
     <Airport ICAO="YCBY" FullName="Cow Bay" Position="-161208.000+1452413.000" />
-    <Airport ICAO="YCCA" FullName="Chinchilla" Position="-264610.000+1503700.000">
+    <Airport ICAO="YCCA" FullName="Chinchilla" Position="-264610.000+1503700.000" Elevation="1030">
       <Runway Name="03" Position="-264619.650+1503706.620" />
       <Runway Name="21" Position="-264604.590+1503719.970" />
       <Runway Name="14" Position="-264605.200+1503651.450" />
       <Runway Name="32" Position="-264632.670+1503715.140" />
     </Airport>
     <Airport ICAO="YCCL" FullName="Collinsville Coal" Position="-203332.000+1474814.000" />
-    <Airport ICAO="YCCT" FullName="Coconut Island" Position="-100300.000+1430400.000" />
-    <Airport ICAO="YCCY" FullName="Cloncurry" Position="-204007.000+1403016.000">
+    <Airport ICAO="YCCT" FullName="Coconut Island" Position="-100300.000+1430400.000" Elevation="10" />
+    <Airport ICAO="YCCY" FullName="Cloncurry" Position="-204007.000+1403016.000" Elevation="613">
       <Runway Name="06" Position="-204013.110+1402954.760" />
       <Runway Name="24" Position="-203959.000+1403031.850" />
       <Runway Name="12" Position="-203936.750+1402958.300" />
       <Runway Name="30" Position="-204016.640+1403052.870" />
     </Airport>
-    <Airport ICAO="YCDE" FullName="Cobden" Position="-381936.000+1430324.000" />
-    <Airport ICAO="YCDH" FullName="Cadney Homestead" Position="-275424.000+1340321.000" />
-    <Airport ICAO="YCDO" FullName="Condobolin" Position="-330352.000+1471233.000">
+    <Airport ICAO="YCDE" FullName="Cobden" Position="-381936.000+1430324.000" Elevation="460" />
+    <Airport ICAO="YCDH" FullName="Cadney Homestead" Position="-275424.000+1340321.000" Elevation="941" />
+    <Airport ICAO="YCDO" FullName="Condobolin" Position="-330352.000+1471233.000" Elevation="654">
       <Runway Name="01" Position="-330412.660+1471238.540" />
       <Runway Name="19" Position="-330332.150+1471300.520" />
       <Runway Name="10" Position="-330346.800+1471159.140" />
       <Runway Name="28" Position="-330356.700+1471243.990" />
     </Airport>
-    <Airport ICAO="YCDR" FullName="Caloundra" Position="-264807.000+1530619.000" />
+    <Airport ICAO="YCDR" FullName="Caloundra" Position="-264807.000+1530619.000" Elevation="38" />
     <Airport ICAO="YCDS" FullName="Childers" Position="-251511.000+1522013.000" />
     <Airport ICAO="YCDT" FullName="Carandotta" Position="-215817.000+1383627.000" />
-    <Airport ICAO="YCDU" FullName="Ceduna" Position="-320750.000+1334235.000">
+    <Airport ICAO="YCDU" FullName="Ceduna" Position="-320750.000+1334235.000" Elevation="77">
       <Runway Name="11" Position="-320740.220+1334152.860" />
       <Runway Name="29" Position="-320800.300+1334254.940" />
       <Runway Name="17" Position="-320735.870+1334245.460" />
       <Runway Name="35" Position="-320808.530+1334249.980" />
     </Airport>
     <Airport ICAO="YCDV" FullName="Caldervale Stn" Position="-250641.000+1464953.000" />
-    <Airport ICAO="YCDW" FullName="Cardwell/Dallachy" Position="-181042.000+1455700.000" />
-    <Airport ICAO="YCEE" FullName="Cleve" Position="-334235.000+1363017.000">
+    <Airport ICAO="YCDW" FullName="Cardwell/Dallachy" Position="-181042.000+1455700.000" Elevation="47" />
+    <Airport ICAO="YCEE" FullName="Cleve" Position="-334235.000+1363017.000" Elevation="589">
       <Runway Name="08" Position="-334236.890+1362957.150" />
       <Runway Name="26" Position="-334237.400+1363049.530" />
       <Runway Name="18" Position="-334227.680+1363015.320" />
       <Runway Name="36" Position="-334256.690+1363014.350" />
     </Airport>
-    <Airport ICAO="YCEL" FullName="Capella" Position="-230600.000+1480000.000" />
-    <Airport ICAO="YCEM" FullName="Coldstream" Position="-374342.000+1452432.000" />
-    <Airport ICAO="YCES" FullName="Ceres" Position="-380846.000+1441542.000" />
+    <Airport ICAO="YCEL" FullName="Capella" Position="-230600.000+1480000.000" Elevation="827" />
+    <Airport ICAO="YCEM" FullName="Coldstream" Position="-374342.000+1452432.000" Elevation="280" />
+    <Airport ICAO="YCES" FullName="Ceres" Position="-380846.000+1441542.000" Elevation="110" />
     <Airport ICAO="YCFH" FullName="Clifton Hills" Position="-270106.000+1385330.000" />
-    <Airport ICAO="YCFN" FullName="Clifton" Position="-275540.000+1515051.000" />
-    <Airport ICAO="YCFS" FullName="Coffs Harbour" Position="-301914.000+1530659.000">
+    <Airport ICAO="YCFN" FullName="Clifton" Position="-275540.000+1515051.000" Elevation="1450" />
+    <Airport ICAO="YCFS" FullName="Coffs Harbour" Position="-301914.000+1530659.000" Elevation="18">
       <Runway Name="03" Position="-302018.150+1530623.570" />
       <Runway Name="21" Position="-301926.950+1530714.360" />
     </Airport>
-    <Airport ICAO="YCGO" FullName="Chillagoe" Position="-170827.000+1443142.000">
+    <Airport ICAO="YCGO" FullName="Chillagoe" Position="-170827.000+1443142.000" Elevation="1123">
       <Runway Name="17" Position="-170800.450+1443142.210" />
       <Runway Name="35" Position="-170832.320+1443143.750" />
     </Airport>
     <Airport ICAO="YCGW" FullName="Barunah Park/Craigwood" Position="-375936.000+1435201.000" />
     <Airport ICAO="YCHD" FullName="Chadwick" Position="-313423.000+1301008.000" />
-    <Airport ICAO="YCHK" FullName="Christmas Creek" Position="-222121.000+1193833.000">
+    <Airport ICAO="YCHK" FullName="Christmas Creek" Position="-222121.000+1193833.000" Elevation="1454">
       <Runway Name="09" Position="-222116.990+1193749.560" />
       <Runway Name="27" Position="-222113.920+1193916.830" />
     </Airport>
-    <Airport ICAO="YCHT" FullName="Charters Towers" Position="-200237.000+1461620.000">
+    <Airport ICAO="YCHT" FullName="Charters Towers" Position="-200237.000+1461620.000" Elevation="955">
       <Runway Name="01" Position="-200248.920+1461607.070" />
       <Runway Name="19" Position="-200217.380+1461615.980" />
       <Runway Name="06" Position="-200251.060+1461558.990" />
       <Runway Name="24" Position="-200224.270+1461651.570" />
     </Airport>
-    <Airport ICAO="YCIN" FullName="Curtin" Position="-173453.000+1234942.000">
+    <Airport ICAO="YCIN" FullName="Curtin" Position="-173453.000+1234942.000" Elevation="300">
       <Runway Name="11" Position="-173432.280+1234854.430" />
       <Runway Name="29" Position="-173506.820+1235031.420" />
     </Airport>
-    <Airport ICAO="YCKI" FullName="Croker Island" Position="-110955.000+1322902.000">
+    <Airport ICAO="YCKI" FullName="Croker Island" Position="-110955.000+1322902.000" Elevation="51">
       <Runway Name="13" Position="-110928.000+1322840.140" />
       <Runway Name="31" Position="-111001.360+1322913.250" />
     </Airport>
-    <Airport ICAO="YCKN" FullName="Cooktown" Position="-152641.000+1451104.000">
+    <Airport ICAO="YCKN" FullName="Cooktown" Position="-152641.000+1451104.000" Elevation="26">
       <Runway Name="11" Position="-152626.650+1451032.010" />
       <Runway Name="29" Position="-152646.000+1451122.820" />
     </Airport>
     <Airport ICAO="YCLA" FullName="Clare" Position="-334948.000+1383655.000" />
     <Airport ICAO="YCLB" FullName="Brukunga/Claremont" Position="-345936.000+1385530.000" />
     <Airport ICAO="YCLN" FullName="Charlie 1" Position="-202512.000+1172442.000" />
-    <Airport ICAO="YCLQ" FullName="Cape Leveque" Position="-162402.000+1225553.000" />
+    <Airport ICAO="YCLQ" FullName="Cape Leveque" Position="-162402.000+1225553.000" Elevation="75" />
     <Airport ICAO="YCMB" FullName="Cambooya Airfield" Position="-274313.000+1515230.000" />
-    <Airport ICAO="YCMH" FullName="Camden Haven" Position="-313954.000+1524430.000" />
-    <Airport ICAO="YCMM" FullName="Cummins Town" Position="-341510.000+1354248.000" />
-    <Airport ICAO="YCMT" FullName="Clermont" Position="-224623.000+1473714.000">
+    <Airport ICAO="YCMH" FullName="Camden Haven" Position="-313954.000+1524430.000" Elevation="7" />
+    <Airport ICAO="YCMM" FullName="Cummins Town" Position="-341510.000+1354248.000" Elevation="199" />
+    <Airport ICAO="YCMT" FullName="Clermont" Position="-224623.000+1473714.000" Elevation="918">
       <Runway Name="01" Position="-224628.840+1473715.570" />
       <Runway Name="19" Position="-224558.060+1473732.800" />
       <Runway Name="15" Position="-224600.700+1473659.400" />
       <Runway Name="33" Position="-224640.410+1473716.150" />
     </Airport>
-    <Airport ICAO="YCMU" FullName="Cunnamulla" Position="-280148.000+1453720.000">
+    <Airport ICAO="YCMU" FullName="Cunnamulla" Position="-280148.000+1453720.000" Elevation="630">
       <Runway Name="06" Position="-280159.780+1453651.920" />
       <Runway Name="24" Position="-280148.690+1453722.960" />
       <Runway Name="12" Position="-280136.180+1453710.940" />
       <Runway Name="30" Position="-280212.490+1453759.430" />
     </Airport>
-    <Airport ICAO="YCMW" FullName="Camooweal" Position="-195442.000+1380730.000">
+    <Airport ICAO="YCMW" FullName="Camooweal" Position="-195442.000+1380730.000" Elevation="780">
       <Runway Name="13" Position="-195437.700+1380714.400" />
       <Runway Name="31" Position="-195506.300+1380744.200" />
     </Airport>
-    <Airport ICAO="YCNF" FullName="Nifty" Position="-214025.000+1213541.000">
+    <Airport ICAO="YCNF" FullName="Nifty" Position="-214025.000+1213541.000" Elevation="968">
       <Runway Name="12" Position="-214011.110+1213516.480" />
       <Runway Name="30" Position="-214041.800+1213619.350" />
     </Airport>
     <Airport ICAO="YCNG" FullName="Cooranga" Position="-365000.000+1401700.000" />
     <Airport ICAO="YCNH" FullName="Carnamah" Position="-294102.000+1155338.000" />
-    <Airport ICAO="YCNK" FullName="Cessnock" Position="-324715.000+1512030.000">
+    <Airport ICAO="YCNK" FullName="Cessnock" Position="-324715.000+1512030.000" Elevation="210">
       <Runway Name="17" Position="-324647.760+1512027.590" />
       <Runway Name="35" Position="-324723.000+1512021.370" />
     </Airport>
-    <Airport ICAO="YCNM" FullName="Coonamble" Position="-305900.000+1482232.000">
+    <Airport ICAO="YCNM" FullName="Coonamble" Position="-305900.000+1482232.000" Elevation="604">
       <Runway Name="05" Position="-305910.680+1482209.690" />
       <Runway Name="23" Position="-305841.460+1482255.990" />
       <Runway Name="12" Position="-305836.530+1482226.330" />
@@ -17653,23 +17669,23 @@ BOFOR
     <Airport ICAO="YCNN" FullName="Coonana" Position="-310200.000+1230930.000" />
     <Airport ICAO="YCNQ" FullName="Coonawarra" Position="-371646.000+1404841.000" />
     <Airport ICAO="YCNT" FullName="Crows Nest" Position="-271553.000+1520331.000" />
-    <Airport ICAO="YCNY" FullName="Century Mine" Position="-184512.000+1384224.000">
+    <Airport ICAO="YCNY" FullName="Century Mine" Position="-184512.000+1384224.000" Elevation="416">
       <Runway Name="14" Position="-184513.530+1384218.320" />
       <Runway Name="32" Position="-184549.450+1384247.930" />
     </Airport>
     <Airport ICAO="YCOD" FullName="Cordillo Downs" Position="-264433.000+1403810.000" />
-    <Airport ICAO="YCOE" FullName="Coen" Position="-134543.000+1430700.000">
+    <Airport ICAO="YCOE" FullName="Coen" Position="-134543.000+1430700.000" Elevation="533">
       <Runway Name="11" Position="-134538.260+1430643.150" />
       <Runway Name="29" Position="-134553.620+1430720.050" />
     </Airport>
-    <Airport ICAO="YCOF" FullName="Coffin Bay" Position="-343520.000+1353018.000" />
-    <Airport ICAO="YCOH" FullName="Cohuna" Position="-354937.000+1441250.000" />
-    <Airport ICAO="YCOM" FullName="Cooma-Snowy Mountains" Position="-361802.000+1485826.000">
+    <Airport ICAO="YCOF" FullName="Coffin Bay" Position="-343520.000+1353018.000" Elevation="13" />
+    <Airport ICAO="YCOH" FullName="Cohuna" Position="-354937.000+1441250.000" Elevation="260" />
+    <Airport ICAO="YCOM" FullName="Cooma-Snowy Mountains" Position="-361802.000+1485826.000" Elevation="3106">
       <Runway Name="18" Position="-361732.180+1485828.870" />
       <Runway Name="36" Position="-361832.650+1485812.040" />
     </Airport>
-    <Airport ICAO="YCOO" FullName="Cooinda" Position="-125410.000+1323156.000" />
-    <Airport ICAO="YCOR" FullName="Corowa" Position="-355925.000+1462105.000">
+    <Airport ICAO="YCOO" FullName="Cooinda" Position="-125410.000+1323156.000" Elevation="43" />
+    <Airport ICAO="YCOR" FullName="Corowa" Position="-355925.000+1462105.000" Elevation="469">
       <Runway Name="05" Position="-360002.870+1462040.860" />
       <Runway Name="23" Position="-355933.830+1462130.320" />
       <Runway Name="14" Position="-355859.120+1462047.190" />
@@ -17677,55 +17693,55 @@ BOFOR
     </Airport>
     <Airport ICAO="YCOT" FullName="Cormorant" Position="-193130.000+1462025.000" />
     <Airport ICAO="YCPL" FullName="Cape Lambert" Position="-203621.000+1170953.000" />
-    <Airport ICAO="YCPR" FullName="Cape Preston" Position="-205838.000+1161630.000">
+    <Airport ICAO="YCPR" FullName="Cape Preston" Position="-205838.000+1161630.000" Elevation="77">
       <Runway Name="08" Position="-205848.440+1161542.810" />
       <Runway Name="26" Position="-205837.430+1161651.070" />
     </Airport>
-    <Airport ICAO="YCPT" FullName="Carrapateena" Position="-311830.000+1372636.000">
+    <Airport ICAO="YCPT" FullName="Carrapateena" Position="-311830.000+1372636.000" Elevation="672">
       <Runway Name="01" Position="-311856.000+1372628.480" />
       <Runway Name="19" Position="-311805.650+1372643.350" />
     </Airport>
     <Airport ICAO="YCRA" FullName="Carinda" Position="-302730.000+1474234.000" />
     <Airport ICAO="YCRD" FullName="Currandooley" Position="-351101.000+1492903.000" />
-    <Airport ICAO="YCRE" FullName="Cressy" Position="-380224.000+1433911.000" />
-    <Airport ICAO="YCRF" FullName="Westbury/Crofton Farm" Position="-412804.000+1465018.000" />
-    <Airport ICAO="YCRG" FullName="Corryong" Position="-361058.000+1475316.000">
+    <Airport ICAO="YCRE" FullName="Cressy" Position="-380224.000+1433911.000" Elevation="420" />
+    <Airport ICAO="YCRF" FullName="Westbury/Crofton Farm" Position="-412804.000+1465018.000" Elevation="570" />
+    <Airport ICAO="YCRG" FullName="Corryong" Position="-361058.000+1475316.000" Elevation="963">
       <Runway Name="06" Position="-361106.430+1475249.210" />
       <Runway Name="24" Position="-361054.170+1475336.280" />
     </Airport>
-    <Airport ICAO="YCRL" FullName="Crookwell" Position="-343000.000+1492700.000" />
+    <Airport ICAO="YCRL" FullName="Crookwell" Position="-343000.000+1492700.000" Elevation="2953" />
     <Airport ICAO="YCRM" FullName="Cradle Mountain" Position="-413439.000+1455629.000" />
-    <Airport ICAO="YCRN" FullName="Cranbourn" Position="-410941.000+1470053.000" />
+    <Airport ICAO="YCRN" FullName="Cranbourn" Position="-410941.000+1470053.000" Elevation="300" />
     <Airport ICAO="YCRO" FullName="Crown Towers Heliport" Position="-315712.000+1155324.000" />
     <Airport ICAO="YCRT" FullName="Carrieton" Position="-322400.000+1383100.000" />
-    <Airport ICAO="YCRY" FullName="Croydon" Position="-181303.000+1421511.000" />
+    <Airport ICAO="YCRY" FullName="Croydon" Position="-181303.000+1421511.000" Elevation="350" />
     <Airport ICAO="YCSP" FullName="Curtin Springs" Position="-251959.000+1314531.000" />
     <Airport ICAO="YCST" FullName="Carcuma/Carcory Station" Position="-353746.000+1401232.000" />
-    <Airport ICAO="YCSV" FullName="Collinsville" Position="-203546.000+1475136.000" />
-    <Airport ICAO="YCTA" FullName="Coolatai" Position="-290839.000+1504329.000" />
-    <Airport ICAO="YCTI" FullName="Cockatoo Island" Position="-160545.000+1233641.000" />
-    <Airport ICAO="YCTM" FullName="Cootamundra" Position="-343728.000+1480209.000">
+    <Airport ICAO="YCSV" FullName="Collinsville" Position="-203546.000+1475136.000" Elevation="591" />
+    <Airport ICAO="YCTA" FullName="Coolatai" Position="-290839.000+1504329.000" Elevation="1230" />
+    <Airport ICAO="YCTI" FullName="Cockatoo Island" Position="-160545.000+1233641.000" Elevation="380" />
+    <Airport ICAO="YCTM" FullName="Cootamundra" Position="-343728.000+1480209.000" Elevation="1110">
       <Runway Name="10" Position="-343727.150+1480143.450" />
       <Runway Name="28" Position="-343736.860+1480214.910" />
       <Runway Name="16" Position="-343701.820+1480208.280" />
       <Runway Name="34" Position="-343738.170+1480213.420" />
     </Airport>
-    <Airport ICAO="YCTN" FullName="Casterton" Position="-373648.000+1412142.000" />
+    <Airport ICAO="YCTN" FullName="Casterton" Position="-373648.000+1412142.000" Elevation="521" />
     <Airport ICAO="YCTO" FullName="Callington" Position="-350621.000+1390317.000" />
-    <Airport ICAO="YCUE" FullName="Cue" Position="-272648.000+1175507.000">
+    <Airport ICAO="YCUE" FullName="Cue" Position="-272648.000+1175507.000" Elevation="1458">
       <Runway Name="04" Position="-272726.680+1175440.150" />
       <Runway Name="22" Position="-272637.980+1175527.280" />
     </Airport>
-    <Airport ICAO="YCUN" FullName="Cunderdin" Position="-313720.000+1171300.000" />
-    <Airport ICAO="YCVA" FullName="Clare Valley" Position="-334230.000+1383500.000" />
-    <Airport ICAO="YCVG" FullName="Calvin Grove" Position="-344148.000+1383442.000" />
+    <Airport ICAO="YCUN" FullName="Cunderdin" Position="-313720.000+1171300.000" Elevation="705" />
+    <Airport ICAO="YCVA" FullName="Clare Valley" Position="-334230.000+1383500.000" Elevation="1120" />
+    <Airport ICAO="YCVG" FullName="Calvin Grove" Position="-344148.000+1383442.000" Elevation="42" />
     <Airport ICAO="YCVS" FullName="Cervantes" Position="-302930.000+1150506.000" />
-    <Airport ICAO="YCWA" FullName="Coondewanna" Position="-225800.000+1184848.000">
+    <Airport ICAO="YCWA" FullName="Coondewanna" Position="-225800.000+1184848.000" Elevation="2327">
       <Runway Name="08" Position="-225803.110+1184819.360" />
       <Runway Name="26" Position="-225756.270+1184922.110" />
     </Airport>
-    <Airport ICAO="YCWL" FullName="Cowell" Position="-334002.000+1365330.000" />
-    <Airport ICAO="YCWR" FullName="Cowra" Position="-335041.000+1483856.000">
+    <Airport ICAO="YCWL" FullName="Cowell" Position="-334002.000+1365330.000" Elevation="127" />
+    <Airport ICAO="YCWR" FullName="Cowra" Position="-335041.000+1483856.000" Elevation="973">
       <Runway Name="03" Position="-335047.090+1483836.150" />
       <Runway Name="21" Position="-335018.610+1483905.950" />
       <Runway Name="15" Position="-335021.160+1483841.600" />
@@ -17735,13 +17751,13 @@ BOFOR
     <Airport ICAO="YCYN" FullName="Coonalpyn" Position="-354131.000+1395118.000" />
     <Airport ICAO="YCYR" FullName="Charnley River" Position="-164400.000+1252621.000" />
     <Airport ICAO="YDAL" FullName="Dalgonally" Position="-200726.000+1411851.000" />
-    <Airport ICAO="YDAY" FullName="Dalby" Position="-270919.000+1511602.000" />
-    <Airport ICAO="YDBI" FullName="Dirranbandi" Position="-283530.000+1481300.000">
+    <Airport ICAO="YDAY" FullName="Dalby" Position="-270919.000+1511602.000" Elevation="1137" />
+    <Airport ICAO="YDBI" FullName="Dirranbandi" Position="-283530.000+1481300.000" Elevation="567">
       <Runway Name="01" Position="-283532.230+1481256.100" />
       <Runway Name="19" Position="-283454.600+1481310.300" />
     </Airport>
-    <Airport ICAO="YDBR" FullName="Dunbar" Position="-160300.000+1422400.000" />
-    <Airport ICAO="YDBY" FullName="Derby" Position="-172212.000+1233938.000">
+    <Airport ICAO="YDBR" FullName="Dunbar" Position="-160300.000+1422400.000" Elevation="163" />
+    <Airport ICAO="YDBY" FullName="Derby" Position="-172212.000+1233938.000" Elevation="24">
       <Runway Name="05" Position="-172228.480+1233929.850" />
       <Runway Name="23" Position="-172207.550+1234002.360" />
       <Runway Name="11" Position="-172207.840+1233912.410" />
@@ -17749,86 +17765,86 @@ BOFOR
     </Airport>
     <Airport ICAO="YDDF" FullName="Drumduff" Position="-160300.000+1430100.000" />
     <Airport ICAO="YDEA" FullName="Bulman/Delara" Position="-134007.000+1341728.000" />
-    <Airport ICAO="YDEK" FullName="Denmark" Position="-345645.000+1172350.000" />
+    <Airport ICAO="YDEK" FullName="Denmark" Position="-345645.000+1172350.000" Elevation="230" />
     <Airport ICAO="YDFD" FullName="Dexfield Park" Position="-312518.000+1524530.000" />
-    <Airport ICAO="YDGA" FullName="Dalgaranga Mine" Position="-274947.000+1171859.000">
+    <Airport ICAO="YDGA" FullName="Dalgaranga Mine" Position="-274947.000+1171859.000" Elevation="1448">
       <Runway Name="11" Position="-274939.910+1171830.770" />
       <Runway Name="29" Position="-274958.090+1171925.560" />
     </Airport>
     <Airport ICAO="YDGN" FullName="Doongan" Position="-152310.000+1261818.000" />
-    <Airport ICAO="YDGU" FullName="Degrussa" Position="-253327.000+1191715.000">
+    <Airport ICAO="YDGU" FullName="Degrussa" Position="-253327.000+1191715.000" Elevation="1823">
       <Runway Name="09" Position="-253330.750+1191640.660" />
       <Runway Name="27" Position="-253329.670+1191749.440" />
     </Airport>
     <Airport ICAO="YDIM" FullName="Dimbulah" Position="-170742.000+1450545.000" />
-    <Airport ICAO="YDKG" FullName="Duketon Gold" Position="-273607.000+1222002.000">
+    <Airport ICAO="YDKG" FullName="Duketon Gold" Position="-273607.000+1222002.000" Elevation="1770">
       <Runway Name="18" Position="-273533.260+1222008.890" />
       <Runway Name="36" Position="-273638.260+1222008.340" />
     </Airport>
     <Airport ICAO="YDKH" FullName="Vergemont/Dalkeith" Position="-233056.000+1431119.000" />
-    <Airport ICAO="YDKI" FullName="Dunk Island" Position="-175615.000+1460826.000" />
+    <Airport ICAO="YDKI" FullName="Dunk Island" Position="-175615.000+1460826.000" Elevation="20" />
     <Airport ICAO="YDLG" FullName="Dooloogarah" Position="-245311.000+1474731.000" />
     <Airport ICAO="YDLH" FullName="Dalhousie" Position="-262542.000+1353024.000" />
-    <Airport ICAO="YDLO" FullName="Darlot" Position="-275225.000+1211618.000">
+    <Airport ICAO="YDLO" FullName="Darlot" Position="-275225.000+1211618.000" Elevation="1513">
       <Runway Name="14" Position="-275205.320+1211550.070" />
       <Runway Name="32" Position="-275247.930+1211643.780" />
     </Airport>
-    <Airport ICAO="YDLQ" FullName="Deniliquin" Position="-353334.000+1445647.000">
+    <Airport ICAO="YDLQ" FullName="Deniliquin" Position="-353334.000+1445647.000" Elevation="316">
       <Runway Name="06" Position="-353339.790+1445625.060" />
       <Runway Name="24" Position="-353323.810+1445709.350" />
       <Runway Name="12" Position="-353309.270+1445634.160" />
       <Runway Name="30" Position="-353346.800+1445711.260" />
     </Airport>
-    <Airport ICAO="YDLT" FullName="Delta Downs" Position="-165930.000+1411900.000" />
-    <Airport ICAO="YDLV" FullName="Delissaville" Position="-123304.000+1304112.000" />
-    <Airport ICAO="YDMG" FullName="Doomadgee" Position="-175613.000+1384859.000">
+    <Airport ICAO="YDLT" FullName="Delta Downs" Position="-165930.000+1411900.000" Elevation="50" />
+    <Airport ICAO="YDLV" FullName="Delissaville" Position="-123304.000+1304112.000" Elevation="112" />
+    <Airport ICAO="YDMG" FullName="Doomadgee" Position="-175613.000+1384859.000" Elevation="160">
       <Runway Name="12" Position="-175559.690+1384828.010" />
       <Runway Name="30" Position="-175626.860+1384916.610" />
     </Airport>
     <Airport ICAO="YDMN" FullName="Daly River Mission" Position="-134505.000+1304124.000" />
     <Airport ICAO="YDNE" FullName="Mundine" Position="-283659.000+1500903.000" />
-    <Airport ICAO="YDNI" FullName="Darnley Island" Position="-093444.000+1434649.000" />
+    <Airport ICAO="YDNI" FullName="Darnley Island" Position="-093444.000+1434649.000" Elevation="220" />
     <Airport ICAO="YDNV" FullName="Dynevor Downs" Position="-280600.000+1442100.000" />
-    <Airport ICAO="YDOC" FullName="Dochra" Position="-323902.000+1511229.000" />
-    <Airport ICAO="YDOD" FullName="Donald" Position="-362137.000+1430027.000">
+    <Airport ICAO="YDOC" FullName="Dochra" Position="-323902.000+1511229.000" Elevation="228" />
+    <Airport ICAO="YDOD" FullName="Donald" Position="-362137.000+1430027.000" Elevation="409">
       <Runway Name="09" Position="-362134.810+1430016.630" />
       <Runway Name="27" Position="-362139.800+1430102.990" />
       <Runway Name="18" Position="-362138.930+1430026.730" />
       <Runway Name="36" Position="-362205.050+1430022.420" />
     </Airport>
-    <Airport ICAO="YDOP" FullName="Donnington Airpark" Position="-193606.000+1465030.000" />
-    <Airport ICAO="YDOR" FullName="Dorunda Station" Position="-163315.000+1414927.000" />
+    <Airport ICAO="YDOP" FullName="Donnington Airpark" Position="-193606.000+1465030.000" Elevation="250" />
+    <Airport ICAO="YDOR" FullName="Dorunda Station" Position="-163315.000+1414927.000" Elevation="90" />
     <Airport ICAO="YDOT" FullName="Dotswood" Position="-193730.000+1461730.000" />
-    <Airport ICAO="YDPD" FullName="Davenport Downs" Position="-240844.000+1410644.000" />
-    <Airport ICAO="YDPO" FullName="Devonport" Position="-411011.000+1462549.000">
+    <Airport ICAO="YDPD" FullName="Davenport Downs" Position="-240844.000+1410644.000" Elevation="312" />
+    <Airport ICAO="YDPO" FullName="Devonport" Position="-411011.000+1462549.000" Elevation="33">
       <Runway Name="06" Position="-411010.980+1462508.930" />
       <Runway Name="24" Position="-410956.690+1462625.470" />
       <Runway Name="14" Position="-410956.420+1462542.890" />
       <Runway Name="32" Position="-411022.510+1462558.170" />
     </Airport>
-    <Airport ICAO="YDRD" FullName="Drysdale River" Position="-154247.000+1262253.000" />
-    <Airport ICAO="YDRH" FullName="Durham Downs" Position="-270430.000+1415400.000" />
-    <Airport ICAO="YDRI" FullName="Durrie" Position="-254105.000+1401324.000" />
-    <Airport ICAO="YDRN" FullName="Drouin" Position="-381232.000+1454946.000" />
+    <Airport ICAO="YDRD" FullName="Drysdale River" Position="-154247.000+1262253.000" Elevation="1180" />
+    <Airport ICAO="YDRH" FullName="Durham Downs" Position="-270430.000+1415400.000" Elevation="380" />
+    <Airport ICAO="YDRI" FullName="Durrie" Position="-254105.000+1401324.000" Elevation="190" />
+    <Airport ICAO="YDRN" FullName="Drouin" Position="-381232.000+1454946.000" Elevation="330" />
     <Airport ICAO="YDRU" FullName="Thangool/Drumburle" Position="-243913.000+1503208.000" />
     <Airport ICAO="YDRW" FullName="Derwent Bridge" Position="-420800.000+1461320.000" />
     <Airport ICAO="YDUG" FullName="Clara Creek/Dungowan" Position="-255950.000+1465559.000" />
-    <Airport ICAO="YDUM" FullName="Dumbleyung" Position="-331921.000+1174438.000" />
-    <Airport ICAO="YDUN" FullName="Dunwich" Position="-273100.000+1532542.000" />
+    <Airport ICAO="YDUM" FullName="Dumbleyung" Position="-331921.000+1174438.000" Elevation="900" />
+    <Airport ICAO="YDUN" FullName="Dunwich" Position="-273100.000+1532542.000" Elevation="250" />
     <Airport ICAO="YDVC" FullName="Devil Creek" Position="-205348.000+1162438.000" />
-    <Airport ICAO="YDVR" FullName="Docker River" Position="-245130.000+1290724.000" />
-    <Airport ICAO="YDWF" FullName="Delamere Range Facility" Position="-154449.000+1315510.000">
+    <Airport ICAO="YDVR" FullName="Docker River" Position="-245130.000+1290724.000" Elevation="1931" />
+    <Airport ICAO="YDWF" FullName="Delamere Range Facility" Position="-154449.000+1315510.000" Elevation="730">
       <Runway Name="09" Position="-154449.360+1315448.430" />
       <Runway Name="27" Position="-154449.520+1315527.030" />
     </Airport>
     <Airport ICAO="YDWN" FullName="Marion Downs" Position="-170423.000+1265053.000" />
     <Airport ICAO="YDWP" FullName="Deepter Point" Position="-164100.000+1230500.000" />
     <Airport ICAO="YDYP" FullName="Dyke Point" Position="-325515.000+1514629.000" />
-    <Airport ICAO="YDYS" FullName="Dysart" Position="-223720.000+1482150.000" />
+    <Airport ICAO="YDYS" FullName="Dysart" Position="-223720.000+1482150.000" Elevation="682" />
     <Airport ICAO="YEAT" FullName="Yea" Position="-371257.000+1452551.000" />
     <Airport ICAO="YEBE" FullName="Woleebee Creek" Position="-261658.000+1494209.000" />
-    <Airport ICAO="YECB" FullName="Eco Beach" Position="-181924.000+1220736.000" />
-    <Airport ICAO="YECH" FullName="Echuca" Position="-360926.000+1444543.000">
+    <Airport ICAO="YECB" FullName="Eco Beach" Position="-181924.000+1220736.000" Elevation="6" />
+    <Airport ICAO="YECH" FullName="Echuca" Position="-360926.000+1444543.000" Elevation="323">
       <Runway Name="05" Position="-360928.570+1444531.600" />
       <Runway Name="23" Position="-360919.920+1444549.010" />
       <Runway Name="17" Position="-360928.130+1444543.100" />
@@ -17840,26 +17856,26 @@ BOFOR
     <Airport ICAO="YEDD" FullName="Eudunda" Position="-341052.000+1390521.000" />
     <Airport ICAO="YEDW" FullName="Eleanor Downs" Position="-355354.000+1371542.000" />
     <Airport ICAO="YEEB" FullName="Eneabba" Position="-294959.000+1151447.000" />
-    <Airport ICAO="YEHP" FullName="Erina Heliport" Position="-332627.000+1512207.000" />
+    <Airport ICAO="YEHP" FullName="Erina Heliport" Position="-332627.000+1512207.000" Elevation="15" />
     <Airport ICAO="YEII" FullName="East Intercourse" Position="-203922.000+1164055.000" />
-    <Airport ICAO="YEJI" FullName="East Jaurdi" Position="-304610.000+1201843.000">
+    <Airport ICAO="YEJI" FullName="East Jaurdi" Position="-304610.000+1201843.000" Elevation="1448">
       <Runway Name="08" Position="-304617.440+1201808.540" />
       <Runway Name="26" Position="-304606.300+1201918.790" />
     </Airport>
-    <Airport ICAO="YELD" FullName="Elcho Island" Position="-120110.000+1353414.000">
+    <Airport ICAO="YELD" FullName="Elcho Island" Position="-120110.000+1353414.000" Elevation="101">
       <Runway Name="10" Position="-120105.110+1353405.840" />
       <Runway Name="28" Position="-120113.150+1353452.730" />
     </Airport>
-    <Airport ICAO="YELN" FullName="Elliston" Position="-333818.000+1345400.000" />
-    <Airport ICAO="YEMG" FullName="Eromanga" Position="-264217.000+1431543.000" />
-    <Airport ICAO="YEML" FullName="Emerald" Position="-233404.000+1481045.000">
+    <Airport ICAO="YELN" FullName="Elliston" Position="-333818.000+1345400.000" Elevation="20" />
+    <Airport ICAO="YEMG" FullName="Eromanga" Position="-264217.000+1431543.000" Elevation="545" />
+    <Airport ICAO="YEML" FullName="Emerald" Position="-233404.000+1481045.000" Elevation="622">
       <Runway Name="06" Position="-233419.980+1481015.950" />
       <Runway Name="24" Position="-233359.350+1481119.100" />
       <Runway Name="15" Position="-233353.460+1481029.320" />
       <Runway Name="33" Position="-233411.090+1481039.790" />
     </Airport>
-    <Airport ICAO="YEMP" FullName="Emu Park" Position="-231524.000+1504848.000" />
-    <Airport ICAO="YENO" FullName="Enoggera Heliport" Position="-272536.000+1525812.000" />
+    <Airport ICAO="YEMP" FullName="Emu Park" Position="-231524.000+1504848.000" Elevation="44" />
+    <Airport ICAO="YENO" FullName="Enoggera Heliport" Position="-272536.000+1525812.000" Elevation="223" />
     <Airport ICAO="YEPA" FullName="Epic Energy One" Position="-284417.000+1400220.000" />
     <Airport ICAO="YEPB" FullName="Epic Energy Two" Position="-293409.000+1395631.000" />
     <Airport ICAO="YEPC" FullName="Epic Energy Three" Position="-302113.000+1393938.000" />
@@ -17868,100 +17884,100 @@ BOFOR
     <Airport ICAO="YEPL" FullName="Epsilon" Position="-281800.000+1411400.000" />
     <Airport ICAO="YEQO" FullName="El Questro" Position="-160018.000+1275818.000" />
     <Airport ICAO="YEQY" FullName="Elizabeth Quay" Position="-315800.000+1155142.000" />
-    <Airport ICAO="YERN" FullName="Ernabella" Position="-261545.000+1321054.000" />
-    <Airport ICAO="YESD" FullName="Eidsvold" Position="-252154.000+1510630.000" />
-    <Airport ICAO="YESE" FullName="Elrose" Position="-205838.000+1410026.000" />
-    <Airport ICAO="YESP" FullName="Esperance" Position="-334104.000+1214922.000">
+    <Airport ICAO="YERN" FullName="Ernabella" Position="-261545.000+1321054.000" Elevation="2319" />
+    <Airport ICAO="YESD" FullName="Eidsvold" Position="-252154.000+1510630.000" Elevation="869" />
+    <Airport ICAO="YESE" FullName="Elrose" Position="-205838.000+1410026.000" Elevation="643" />
+    <Airport ICAO="YESP" FullName="Esperance" Position="-334104.000+1214922.000" Elevation="471">
       <Runway Name="03" Position="-334120.840+1214915.910" />
       <Runway Name="21" Position="-334047.220+1214937.660" />
       <Runway Name="11" Position="-334045.340+1214846.030" />
       <Runway Name="29" Position="-334106.210+1214951.210" />
     </Airport>
     <Airport ICAO="YETT" FullName="North Gregory/Elliott Field" Position="-250301.000+1521316.000" />
-    <Airport ICAO="YEUA" FullName="Euroa" Position="-364441.000+1453048.000" />
-    <Airport ICAO="YEUO" FullName="Eulo" Position="-281009.000+1450230.000" />
-    <Airport ICAO="YEVD" FullName="Evans Head" Position="-290536.000+1532513.000" />
+    <Airport ICAO="YEUA" FullName="Euroa" Position="-364441.000+1453048.000" Elevation="555" />
+    <Airport ICAO="YEUO" FullName="Eulo" Position="-281009.000+1450230.000" Elevation="500" />
+    <Airport ICAO="YEVD" FullName="Evans Head" Position="-290536.000+1532513.000" Elevation="20" />
     <Airport ICAO="YEVP" FullName="Everard Park" Position="-270212.000+1324054.000" />
-    <Airport ICAO="YEWA" FullName="Eliwana" Position="-222544.000+1165314.000">
+    <Airport ICAO="YEWA" FullName="Eliwana" Position="-222544.000+1165314.000" Elevation="1576">
       <Runway Name="10" Position="-222535.220+1165233.290" />
       <Runway Name="28" Position="-222549.210+1165359.450" />
     </Airport>
-    <Airport ICAO="YEXM" FullName="Exmouth" Position="-220229.000+1140608.000" />
+    <Airport ICAO="YEXM" FullName="Exmouth" Position="-220229.000+1140608.000" Elevation="10" />
     <Airport ICAO="YEYD" FullName="Evelyn Downs" Position="-281217.000+1342918.000" />
     <Airport ICAO="YFAR" FullName="Farnsfield" Position="-250700.000+1521739.000" />
     <Airport ICAO="YFBR" FullName="Fairy Bower" Position="-305259.000+1481447.000" />
-    <Airport ICAO="YFBS" FullName="Forbes" Position="-332149.000+1475606.000">
+    <Airport ICAO="YFBS" FullName="Forbes" Position="-332149.000+1475606.000" Elevation="760">
       <Runway Name="09" Position="-332142.440+1475516.360" />
       <Runway Name="27" Position="-332148.730+1475603.240" />
     </Airport>
-    <Airport ICAO="YFDF" FullName="Fortescue Dave Forrest" Position="-221731.000+1192614.000">
+    <Airport ICAO="YFDF" FullName="Fortescue Dave Forrest" Position="-221731.000+1192614.000" Elevation="1563">
       <Runway Name="12" Position="-221707.600+1192545.020" />
       <Runway Name="30" Position="-221749.560+1192651.470" />
     </Airport>
-    <Airport ICAO="YFDN" FullName="Federation" Position="-350046.000+1472225.000" />
-    <Airport ICAO="YFFD" FullName="Stirling North/Flinders Field" Position="-323203.000+1375129.000" />
+    <Airport ICAO="YFDN" FullName="Federation" Position="-350046.000+1472225.000" Elevation="710" />
+    <Airport ICAO="YFFD" FullName="Stirling North/Flinders Field" Position="-323203.000+1375129.000" Elevation="110" />
     <Airport ICAO="YFHA" FullName="Finch Hatton" Position="-210827.000+1483855.000" />
     <Airport ICAO="YFIG" FullName="Irongate/Fig Tree" Position="-273816.000+1513045.000" />
     <Airport ICAO="YFLD" FullName="Facing Island" Position="-235324.000+1513400.000" />
-    <Airport ICAO="YFLI" FullName="Flinders Island" Position="-400529.000+1475934.000">
+    <Airport ICAO="YFLI" FullName="Flinders Island" Position="-400529.000+1475934.000" Elevation="33">
       <Runway Name="05" Position="-400540.030+1475935.440" />
       <Runway Name="23" Position="-400524.230+1480012.980" />
       <Runway Name="14" Position="-400458.360+1475858.110" />
       <Runway Name="32" Position="-400543.270+1475941.130" />
     </Airport>
     <Airport ICAO="YFLK" FullName="Falls Creek" Position="-365200.000+1471700.000" />
-    <Airport ICAO="YFRG" FullName="Fregon" Position="-264633.000+1320103.000" />
+    <Airport ICAO="YFRG" FullName="Fregon" Position="-264633.000+1320103.000" Elevation="1732" />
     <Airport ICAO="YFRK" FullName="Frankland Valley" Position="-342051.000+1165650.000" />
-    <Airport ICAO="YFRT" FullName="Forrest" Position="-305017.000+1280654.000">
+    <Airport ICAO="YFRT" FullName="Forrest" Position="-305017.000+1280654.000" Elevation="511">
       <Runway Name="09" Position="-305011.340+1280634.680" />
       <Runway Name="27" Position="-305014.230+1280725.610" />
       <Runway Name="18" Position="-304957.630+1280646.150" />
       <Runway Name="36" Position="-305047.030+1280646.510" />
     </Airport>
-    <Airport ICAO="YFTA" FullName="Forrestania" Position="-323442.000+1194224.000">
+    <Airport ICAO="YFTA" FullName="Forrestania" Position="-323442.000+1194224.000" Elevation="1362">
       <Runway Name="15" Position="-323435.510+1194211.740" />
       <Runway Name="33" Position="-323516.340+1194245.090" />
     </Airport>
     <Airport ICAO="YFTL" FullName="Fremantle Heliport" Position="-320243.000+1154359.000" />
-    <Airport ICAO="YFTZ" FullName="Fitzroy Crossing" Position="-181055.000+1253331.000">
+    <Airport ICAO="YFTZ" FullName="Fitzroy Crossing" Position="-181055.000+1253331.000" Elevation="368">
       <Runway Name="01" Position="-181121.060+1253328.640" />
       <Runway Name="19" Position="-181040.530+1253341.950" />
     </Airport>
-    <Airport ICAO="YGAD" FullName="Garden Island Heliport" Position="-321430.000+1154102.000" />
+    <Airport ICAO="YGAD" FullName="Garden Island Heliport" Position="-321430.000+1154102.000" Elevation="36" />
     <Airport ICAO="YGAM" FullName="Gamboola" Position="-163236.000+1434012.000" />
     <Airport ICAO="YGAR" FullName="Macleod/Gnaraloo Bay" Position="-234728.000+1133149.000" />
-    <Airport ICAO="YGAS" FullName="Gatton Airpark" Position="-273524.000+1521524.000" />
-    <Airport ICAO="YGAW" FullName="Gawler" Position="-343555.000+1384317.000" />
-    <Airport ICAO="YGAY" FullName="Gayndah" Position="-253655.000+1513715.000">
+    <Airport ICAO="YGAS" FullName="Gatton Airpark" Position="-273524.000+1521524.000" Elevation="460" />
+    <Airport ICAO="YGAW" FullName="Gawler" Position="-343555.000+1384317.000" Elevation="165" />
+    <Airport ICAO="YGAY" FullName="Gayndah" Position="-253655.000+1513715.000" Elevation="372">
       <Runway Name="06" Position="-253705.340+1513654.700" />
       <Runway Name="24" Position="-253648.170+1513735.910" />
     </Airport>
-    <Airport ICAO="YGBF" FullName="Barwon Field" Position="-380849.000+1441021.000" />
-    <Airport ICAO="YGBI" FullName="South Goulburn Island" Position="-113902.000+1332255.000">
+    <Airport ICAO="YGBF" FullName="Barwon Field" Position="-380849.000+1441021.000" Elevation="260" />
+    <Airport ICAO="YGBI" FullName="South Goulburn Island" Position="-113902.000+1332255.000" Elevation="63">
       <Runway Name="10" Position="-113857.540+1332207.930" />
       <Runway Name="28" Position="-113904.970+1332252.890" />
     </Airport>
     <Airport ICAO="YGBK" FullName="Glenbrook Hls" Position="-334542.000+1503810.000" />
-    <Airport ICAO="YGDA" FullName="Goodooga" Position="-290424.000+1472234.000">
+    <Airport ICAO="YGDA" FullName="Goodooga" Position="-290424.000+1472234.000" Elevation="459">
       <Runway Name="12" Position="-290411.120+1472250.870" />
       <Runway Name="30" Position="-290433.010+1472319.660" />
     </Airport>
-    <Airport ICAO="YGDH" FullName="Gunnedah" Position="-305740.000+1501502.000">
+    <Airport ICAO="YGDH" FullName="Gunnedah" Position="-305740.000+1501502.000" Elevation="863">
       <Runway Name="11" Position="-305712.960+1501426.140" />
       <Runway Name="29" Position="-305741.870+1501518.340" />
       <Runway Name="17" Position="-305718.770+1501503.440" />
       <Runway Name="35" Position="-305736.970+1501502.440" />
     </Airport>
-    <Airport ICAO="YGDI" FullName="Goondiwindi" Position="-283117.000+1501913.000">
+    <Airport ICAO="YGDI" FullName="Goondiwindi" Position="-283117.000+1501913.000" Elevation="714">
       <Runway Name="04" Position="-283137.280+1501855.980" />
       <Runway Name="22" Position="-283104.970+1501929.030" />
       <Runway Name="12" Position="-283114.650+1501904.270" />
       <Runway Name="30" Position="-283131.780+1501926.200" />
     </Airport>
-    <Airport ICAO="YGDO" FullName="Gundaroo" Position="-350242.000+1491530.000" />
+    <Airport ICAO="YGDO" FullName="Gundaroo" Position="-350242.000+1491530.000" Elevation="1860" />
     <Airport ICAO="YGDR" FullName="The Garden" Position="-231712.000+1342624.000" />
-    <Airport ICAO="YGDS" FullName="Gregory Downs" Position="-183732.000+1391401.000" />
-    <Airport ICAO="YGEL" FullName="Geraldton" Position="-284746.000+1144227.000">
+    <Airport ICAO="YGDS" FullName="Gregory Downs" Position="-183732.000+1391401.000" Elevation="170" />
+    <Airport ICAO="YGEL" FullName="Geraldton" Position="-284746.000+1144227.000" Elevation="121">
       <Runway Name="03" Position="-284828.730+1144207.440" />
       <Runway Name="21" Position="-284715.110+1144235.210" />
       <Runway Name="08" Position="-284716.640+1144158.310" />
@@ -17970,39 +17986,39 @@ BOFOR
       <Runway Name="32" Position="-284738.880+1144220.550" />
     </Airport>
     <Airport ICAO="YGEN" FullName="The Glen Airfield" Position="-224921.000+1501956.000" />
-    <Airport ICAO="YGFN" FullName="Grafton" Position="-294534.000+1530148.000">
+    <Airport ICAO="YGFN" FullName="Grafton" Position="-294534.000+1530148.000" Elevation="110">
       <Runway Name="18" Position="-294449.780+1530155.350" />
       <Runway Name="36" Position="-294544.950+1530149.540" />
     </Airport>
-    <Airport ICAO="YGGE" FullName="Golden Grove" Position="-284554.000+1165818.000">
+    <Airport ICAO="YGGE" FullName="Golden Grove" Position="-284554.000+1165818.000" Elevation="1183">
       <Runway Name="11" Position="-284541.100+1165754.010" />
       <Runway Name="29" Position="-284601.230+1165840.120" />
     </Airport>
-    <Airport ICAO="YGGI" FullName="Goolgowi" Position="-335931.000+1454309.000" />
-    <Airport ICAO="YGHP" FullName="Glenample Heliport" Position="-383937.000+1430622.000" />
+    <Airport ICAO="YGGI" FullName="Goolgowi" Position="-335931.000+1454309.000" Elevation="400" />
+    <Airport ICAO="YGHP" FullName="Glenample Heliport" Position="-383937.000+1430622.000" Elevation="200" />
     <Airport ICAO="YGHS" FullName="Macleod/Gnaraloo Homestead" Position="-234930.000+1133148.000" />
-    <Airport ICAO="YGIA" FullName="Ginbata" Position="-223452.000+1200208.000">
+    <Airport ICAO="YGIA" FullName="Ginbata" Position="-223452.000+1200208.000" Elevation="1409">
       <Runway Name="09" Position="-223453.830+1200124.570" />
       <Runway Name="27" Position="-223453.830+1200252.020" />
     </Airport>
-    <Airport ICAO="YGIB" FullName="Gibb River" Position="-162507.000+1262646.000" />
-    <Airport ICAO="YGIG" FullName="Gingin" Position="-312755.000+1155148.000">
+    <Airport ICAO="YGIB" FullName="Gibb River" Position="-162507.000+1262646.000" Elevation="1669" />
+    <Airport ICAO="YGIG" FullName="Gingin" Position="-312755.000+1155148.000" Elevation="247">
       <Runway Name="08" Position="-312759.360+1155113.430" />
       <Runway Name="26" Position="-312743.990+1155220.330" />
     </Airport>
-    <Airport ICAO="YGIL" FullName="Gilgandra" Position="-314149.000+1483810.000" />
-    <Airport ICAO="YGLA" FullName="Gladstone" Position="-235211.000+1511322.000">
+    <Airport ICAO="YGIL" FullName="Gilgandra" Position="-314149.000+1483810.000" Elevation="947" />
+    <Airport ICAO="YGLA" FullName="Gladstone" Position="-235211.000+1511322.000" Elevation="59">
       <Runway Name="10" Position="-235200.850+1511301.240" />
       <Runway Name="28" Position="-235219.400+1511356.320" />
     </Airport>
-    <Airport ICAO="YGLB" FullName="Goulburn" Position="-344837.000+1494335.000">
+    <Airport ICAO="YGLB" FullName="Goulburn" Position="-344837.000+1494335.000" Elevation="2141">
       <Runway Name="04" Position="-344847.610+1494318.140" />
       <Runway Name="22" Position="-344819.580+1494355.380" />
       <Runway Name="08" Position="-344834.870+1494338.360" />
       <Runway Name="26" Position="-344835.640+1494405.090" />
     </Airport>
     <Airport ICAO="YGLE" FullName="Glengyle" Position="-244830.000+1393600.000" />
-    <Airport ICAO="YGLI" FullName="Glen Innes" Position="-294030.000+1514122.000">
+    <Airport ICAO="YGLI" FullName="Glen Innes" Position="-294030.000+1514122.000" Elevation="3431">
       <Runway Name="10" Position="-294026.070+1514056.860" />
       <Runway Name="28" Position="-294036.730+1514139.800" />
       <Runway Name="14" Position="-294001.410+1514110.240" />
@@ -18010,34 +18026,34 @@ BOFOR
     </Airport>
     <Airport ICAO="YGLK" FullName="Glenbrook Npws" Position="-334715.000+1503631.000" />
     <Airport ICAO="YGLM" FullName="Glendell Mine" Position="-322606.000+1510352.000" />
-    <Airport ICAO="YGLO" FullName="Glenormiston" Position="-225320.000+1384927.000" />
-    <Airport ICAO="YGLS" FullName="Giles" Position="-250300.000+1281800.000" />
+    <Airport ICAO="YGLO" FullName="Glenormiston" Position="-225320.000+1384927.000" Elevation="519" />
+    <Airport ICAO="YGLS" FullName="Giles" Position="-250300.000+1281800.000" Elevation="1900" />
     <Airport ICAO="YGMS" FullName="Greymare/Mountain Station" Position="-281212.000+1514618.000" />
     <Airport ICAO="YGMT" FullName="Greenmount" Position="-274549.000+1515530.000" />
     <Airport ICAO="YGNA" FullName="Granada" Position="-200547.000+1402150.000" />
-    <Airport ICAO="YGNE" FullName="Gnarwarre" Position="-380954.000+1440627.000" />
+    <Airport ICAO="YGNE" FullName="Gnarwarre" Position="-380954.000+1440627.000" Elevation="420" />
     <Airport ICAO="YGNI" FullName="Green Island (Cairns)" Position="-164530.000+1455830.000" />
     <Airport ICAO="YGNV" FullName="Greenvale" Position="-190000.000+1450100.000" />
-    <Airport ICAO="YGNW" FullName="Gnowangerup" Position="-335837.000+1180040.000">
+    <Airport ICAO="YGNW" FullName="Gnowangerup" Position="-335837.000+1180040.000" Elevation="920">
       <Runway Name="12" Position="-335828.680+1180020.200" />
       <Runway Name="30" Position="-335854.260+1180109.880" />
     </Airport>
     <Airport ICAO="YGOD" FullName="Goldfields/Loloma" Position="-282810.000+1514623.000" />
-    <Airport ICAO="YGON" FullName="Mount Gordon" Position="-194619.000+1392404.000">
+    <Airport ICAO="YGON" FullName="Mount Gordon" Position="-194619.000+1392404.000" Elevation="900">
       <Runway Name="08" Position="-194621.490+1392355.120" />
       <Runway Name="26" Position="-194621.540+1392435.140" />
     </Airport>
-    <Airport ICAO="YGPT" FullName="Garden Point" Position="-112357.000+1302531.000">
+    <Airport ICAO="YGPT" FullName="Garden Point" Position="-112357.000+1302531.000" Elevation="90">
       <Runway Name="04" Position="-112414.790+1302517.590" />
       <Runway Name="22" Position="-112342.810+1302546.500" />
     </Airport>
-    <Airport ICAO="YGRL" FullName="Great Lakes Airfield" Position="-375033.000+1480001.000" />
-    <Airport ICAO="YGRM" FullName="Gruyere" Position="-280203.000+1234851.000">
+    <Airport ICAO="YGRL" FullName="Great Lakes Airfield" Position="-375033.000+1480001.000" Elevation="260" />
+    <Airport ICAO="YGRM" FullName="Gruyere" Position="-280203.000+1234851.000" Elevation="1542">
       <Runway Name="06" Position="-280219.150+1234817.170" />
       <Runway Name="24" Position="-280150.570+1234927.010" />
     </Airport>
     <Airport ICAO="YGRO" FullName="Gore/Rooaroo" Position="-281848.000+1512654.000" />
-    <Airport ICAO="YGRS" FullName="Granny Smith" Position="-284548.000+1222616.000">
+    <Airport ICAO="YGRS" FullName="Granny Smith" Position="-284548.000+1222616.000" Elevation="1457">
       <Runway Name="16" Position="-284519.830+1222604.200" />
       <Runway Name="34" Position="-284615.990+1222632.410" />
     </Airport>
@@ -18046,48 +18062,48 @@ BOFOR
     <Airport ICAO="YGSN" FullName="Mount Gibson" Position="-293626.000+1172411.000" />
     <Airport ICAO="YGST" FullName="Grundy Street Helipad" Position="-165739.000+1454459.000" />
     <Airport ICAO="YGTC" FullName="Anmatjere/Gemtree Cara V An Park" Position="-225812.000+1341451.000" />
-    <Airport ICAO="YGTE" FullName="Groote Eylandt" Position="-135824.000+1362739.000">
+    <Airport ICAO="YGTE" FullName="Groote Eylandt" Position="-135824.000+1362739.000" Elevation="53">
       <Runway Name="10" Position="-135815.750+1362659.620" />
       <Runway Name="28" Position="-135825.580+1362802.230" />
     </Airport>
-    <Airport ICAO="YGTH" FullName="Griffith" Position="-341503.000+1460402.000">
+    <Airport ICAO="YGTH" FullName="Griffith" Position="-341503.000+1460402.000" Elevation="439">
       <Runway Name="06" Position="-341525.990+1460306.560" />
       <Runway Name="24" Position="-341503.300+1460407.320" />
       <Runway Name="18" Position="-341447.980+1460406.730" />
       <Runway Name="36" Position="-341507.250+1460403.260" />
     </Airport>
     <Airport ICAO="YGTM" FullName="Bundoora/Grasstree Mine" Position="-225921.000+1483439.000" />
-    <Airport ICAO="YGTN" FullName="Georgetown (Qld)" Position="-181812.000+1433151.000">
+    <Airport ICAO="YGTN" FullName="Georgetown (Qld)" Position="-181812.000+1433151.000" Elevation="995">
       <Runway Name="06" Position="-181818.180+1433133.250" />
       <Runway Name="24" Position="-181801.420+1433208.710" />
     </Airport>
-    <Airport ICAO="YGTO" FullName="George Town (Tas)" Position="-410448.000+1465024.000" />
-    <Airport ICAO="YGWA" FullName="Goolwa" Position="-352855.000+1384505.000" />
+    <Airport ICAO="YGTO" FullName="George Town (Tas)" Position="-410448.000+1465024.000" Elevation="120" />
+    <Airport ICAO="YGWA" FullName="Goolwa" Position="-352855.000+1384505.000" Elevation="104" />
     <Airport ICAO="YGWN" FullName="Goodwyn Platform" Position="-193907.000+1155547.000" />
-    <Airport ICAO="YGYM" FullName="Gympie" Position="-261658.000+1524207.000" />
-    <Airport ICAO="YHAA" FullName="Haasts Bluff" Position="-232702.000+1315105.000" />
-    <Airport ICAO="YHAE" FullName="Harden" Position="-343345.000+1482330.000" />
+    <Airport ICAO="YGYM" FullName="Gympie" Position="-261658.000+1524207.000" Elevation="260" />
+    <Airport ICAO="YHAA" FullName="Haasts Bluff" Position="-232702.000+1315105.000" Elevation="2269" />
+    <Airport ICAO="YHAE" FullName="Harden" Position="-343345.000+1482330.000" Elevation="1444" />
     <Airport ICAO="YHAG" FullName="Haig" Position="-310000.000+1260500.000" />
-    <Airport ICAO="YHAW" FullName="Hawker" Position="-315117.000+1382806.000" />
-    <Airport ICAO="YHAY" FullName="Hay" Position="-343153.000+1444947.000">
+    <Airport ICAO="YHAW" FullName="Hawker" Position="-315117.000+1382806.000" Elevation="1052" />
+    <Airport ICAO="YHAY" FullName="Hay" Position="-343153.000+1444947.000" Elevation="305">
       <Runway Name="04" Position="-343214.670+1444926.210" />
       <Runway Name="22" Position="-343140.290+1445005.780" />
       <Runway Name="15" Position="-343125.910+1444937.430" />
       <Runway Name="33" Position="-343159.360+1444956.690" />
     </Airport>
-    <Airport ICAO="YHBA" FullName="Hervey Bay" Position="-251908.000+1525249.000">
+    <Airport ICAO="YHBA" FullName="Hervey Bay" Position="-251908.000+1525249.000" Elevation="60">
       <Runway Name="11" Position="-251856.100+1525217.530" />
       <Runway Name="29" Position="-251927.260+1525320.290" />
     </Airport>
     <Airport ICAO="YHBH" FullName="Heidelberg Hospital" Position="-374454.000+1450210.000" />
-    <Airport ICAO="YHBK" FullName="Holbrook" Position="-354100.000+1471900.000" />
-    <Airport ICAO="YHCS" FullName="Herbertvale Cattleyard" Position="-185731.000+1380344.000" />
+    <Airport ICAO="YHBK" FullName="Holbrook" Position="-354100.000+1471900.000" Elevation="875" />
+    <Airport ICAO="YHCS" FullName="Herbertvale Cattleyard" Position="-185731.000+1380344.000" Elevation="804" />
     <Airport ICAO="YHDY" FullName="Headingly" Position="-211917.000+1381749.000" />
-    <Airport ICAO="YHEC" FullName="Heck Field" Position="-274603.000+1532022.000" />
+    <Airport ICAO="YHEC" FullName="Heck Field" Position="-274603.000+1532022.000" Elevation="10" />
     <Airport ICAO="YHEW" FullName="Hedlow" Position="-231324.000+1503619.000" />
     <Airport ICAO="YHGS" FullName="Hughes Siding" Position="-304300.000+1293054.000" />
     <Airport ICAO="YHHY" FullName="Highbury" Position="-162524.000+1430842.000" />
-    <Airport ICAO="YHID" FullName="Horn Island" Position="-103511.000+1421724.000">
+    <Airport ICAO="YHID" FullName="Horn Island" Position="-103511.000+1421724.000" Elevation="43">
       <Runway Name="08" Position="-103512.020+1421652.470" />
       <Runway Name="26" Position="-103507.930+1421738.000" />
       <Runway Name="14" Position="-103451.590+1421719.640" />
@@ -18095,7 +18111,7 @@ BOFOR
     </Airport>
     <Airport ICAO="YHIP" FullName="Port Hedland Heliport" Position="-201854.000+1183432.000" />
     <Airport ICAO="YHIV" FullName="Hidden Valley" Position="-163300.000+1325400.000" />
-    <Airport ICAO="YHLC" FullName="Halls Creek" Position="-181402.000+1274011.000">
+    <Airport ICAO="YHLC" FullName="Halls Creek" Position="-181402.000+1274011.000" Elevation="1346">
       <Runway Name="04" Position="-181427.350+1273941.070" />
       <Runway Name="22" Position="-181352.740+1274015.830" />
       <Runway Name="08" Position="-181408.130+1273947.470" />
@@ -18103,32 +18119,32 @@ BOFOR
     </Airport>
     <Airport ICAO="YHLF" FullName="Highland Farm" Position="-343637.000+1500547.000" />
     <Airport ICAO="YHLN" FullName="Helen Springs" Position="-182500.000+1335300.000" />
-    <Airport ICAO="YHLS" FullName="Hillston" Position="-332937.000+1453125.000" />
-    <Airport ICAO="YHMB" FullName="Hermannsburg" Position="-235540.000+1324845.000" />
+    <Airport ICAO="YHLS" FullName="Hillston" Position="-332937.000+1453125.000" Elevation="403" />
+    <Airport ICAO="YHMB" FullName="Hermannsburg" Position="-235540.000+1324845.000" Elevation="1945" />
     <Airport ICAO="YHMH" FullName="Hillarys Marina Helipad" Position="-314929.000+1154404.000" />
-    <Airport ICAO="YHML" FullName="Hamilton" Position="-373856.000+1420355.000">
+    <Airport ICAO="YHML" FullName="Hamilton" Position="-373856.000+1420355.000" Elevation="803">
       <Runway Name="10" Position="-373845.510+1420333.480" />
       <Runway Name="28" Position="-373901.360+1420419.660" />
       <Runway Name="17" Position="-373819.130+1420342.930" />
       <Runway Name="35" Position="-373914.420+1420342.810" />
     </Airport>
-    <Airport ICAO="YHON" FullName="Honeymoon" Position="-314512.000+1403954.000" />
-    <Airport ICAO="YHOO" FullName="Hooker Creek" Position="-181942.000+1303848.000" />
-    <Airport ICAO="YHOT" FullName="Mount Hotham" Position="-370254.000+1472003.000">
+    <Airport ICAO="YHON" FullName="Honeymoon" Position="-314512.000+1403954.000" Elevation="416" />
+    <Airport ICAO="YHOO" FullName="Hooker Creek" Position="-181942.000+1303848.000" Elevation="1089" />
+    <Airport ICAO="YHOT" FullName="Mount Hotham" Position="-370254.000+1472003.000" Elevation="4260">
       <Runway Name="11" Position="-370240.370+1471942.110" />
       <Runway Name="29" Position="-370306.490+1472031.380" />
     </Airport>
-    <Airport ICAO="YHPN" FullName="Hopetoun" Position="-354255.000+1422135.000">
+    <Airport ICAO="YHPN" FullName="Hopetoun" Position="-354255.000+1422135.000" Elevation="256">
       <Runway Name="01" Position="-354311.500+1422129.960" />
       <Runway Name="19" Position="-354237.680+1422145.200" />
       <Runway Name="08" Position="-354250.260+1422127.400" />
       <Runway Name="26" Position="-354250.200+1422146.770" />
     </Airport>
-    <Airport ICAO="YHRD" FullName="Hungerford" Position="-285946.000+1442711.000" />
+    <Airport ICAO="YHRD" FullName="Hungerford" Position="-285946.000+1442711.000" Elevation="600" />
     <Airport ICAO="YHRG" FullName="Haddon Rig" Position="-312800.000+1475400.000" />
     <Airport ICAO="YHRN" FullName="Heron Island" Position="-232630.000+1515441.000" />
     <Airport ICAO="YHSJ" FullName="Holt Street Jetty" Position="-272623.000+1530627.000" />
-    <Airport ICAO="YHSM" FullName="Horsham" Position="-364011.000+1421022.000">
+    <Airport ICAO="YHSM" FullName="Horsham" Position="-364011.000+1421022.000" Elevation="445">
       <Runway Name="08" Position="-364007.970+1421014.770" />
       <Runway Name="26" Position="-364007.750+1421107.970" />
       <Runway Name="17" Position="-364011.440+1421019.240" />
@@ -18137,7 +18153,7 @@ BOFOR
     <Airport ICAO="YHTA" FullName="Hiltaba" Position="-320833.000+1350558.000" />
     <Airport ICAO="YHTF" FullName="Hunt Field" Position="-351018.000+1382930.000" />
     <Airport ICAO="YHTN" FullName="Herberton" Position="-172600.000+1452348.000" />
-    <Airport ICAO="YHUG" FullName="Hughenden" Position="-204854.000+1441331.000">
+    <Airport ICAO="YHUG" FullName="Hughenden" Position="-204854.000+1441331.000" Elevation="1043">
       <Runway Name="06" Position="-204912.140+1441251.260" />
       <Runway Name="24" Position="-204854.630+1441332.520" />
       <Runway Name="12" Position="-204829.800+1441307.360" />
@@ -18145,160 +18161,160 @@ BOFOR
     </Airport>
     <Airport ICAO="YHVF" FullName="Angaston/Hutton Vale" Position="-343059.000+1390631.000" />
     <Airport ICAO="YHYL" FullName="Hoyleton" Position="-340132.000+1383129.000" />
-    <Airport ICAO="YIBO" FullName="Iron Bridge Mine" Position="-211712.000+1185259.000">
+    <Airport ICAO="YIBO" FullName="Iron Bridge Mine" Position="-211712.000+1185259.000" Elevation="665">
       <Runway Name="12" Position="-211655.080+1185213.320" />
       <Runway Name="30" Position="-211731.110+1185331.060" />
     </Airport>
     <Airport ICAO="YIFF" FullName="Iffley Hs" Position="-221412.000+1482559.000" />
-    <Airport ICAO="YIFL" FullName="Innisfail/Mundoo" Position="-173331.000+1460042.000">
+    <Airport ICAO="YIFL" FullName="Innisfail/Mundoo" Position="-173331.000+1460042.000" Elevation="46">
       <Runway Name="03" Position="-173351.670+1460031.240" />
       <Runway Name="21" Position="-173315.890+1460057.420" />
       <Runway Name="14" Position="-173315.220+1460025.480" />
       <Runway Name="32" Position="-173349.480+1460054.320" />
     </Airport>
-    <Airport ICAO="YIFY" FullName="Iffley" Position="-185400.000+1411300.000" />
-    <Airport ICAO="YIGM" FullName="Ingham" Position="-183938.000+1460906.000" />
-    <Airport ICAO="YIKM" FullName="Inkerman Station" Position="-161345.000+1412602.000" />
-    <Airport ICAO="YILF" FullName="Ilfracombe" Position="-232818.000+1443203.000" />
-    <Airport ICAO="YIMB" FullName="Kimba" Position="-330526.000+1362752.000">
+    <Airport ICAO="YIFY" FullName="Iffley" Position="-185400.000+1411300.000" Elevation="140" />
+    <Airport ICAO="YIGM" FullName="Ingham" Position="-183938.000+1460906.000" Elevation="49" />
+    <Airport ICAO="YIKM" FullName="Inkerman Station" Position="-161345.000+1412602.000" Elevation="20" />
+    <Airport ICAO="YILF" FullName="Ilfracombe" Position="-232818.000+1443203.000" Elevation="720" />
+    <Airport ICAO="YIMB" FullName="Kimba" Position="-330526.000+1362752.000" Elevation="763">
       <Runway Name="03" Position="-330555.020+1362739.010" />
       <Runway Name="21" Position="-330515.840+1362818.390" />
       <Runway Name="15" Position="-330500.780+1362738.760" />
       <Runway Name="33" Position="-330534.740+1362753.280" />
     </Airport>
-    <Airport ICAO="YIMT" FullName="Innamincka Township" Position="-274430.000+1404442.000" />
-    <Airport ICAO="YINJ" FullName="Injune" Position="-255100.000+1483300.000" />
-    <Airport ICAO="YINN" FullName="Innamincka" Position="-274200.000+1404400.000" />
+    <Airport ICAO="YIMT" FullName="Innamincka Township" Position="-274430.000+1404442.000" Elevation="180" />
+    <Airport ICAO="YINJ" FullName="Injune" Position="-255100.000+1483300.000" Elevation="1325" />
+    <Airport ICAO="YINN" FullName="Innamincka" Position="-274200.000+1404400.000" Elevation="178" />
     <Airport ICAO="YINT" FullName="Integra Coal" Position="-322754.000+1510754.000" />
-    <Airport ICAO="YISF" FullName="Isisford" Position="-241533.000+1442527.000" />
-    <Airport ICAO="YITT" FullName="Mitta Mitta" Position="-363044.000+1472122.000" />
+    <Airport ICAO="YISF" FullName="Isisford" Position="-241533.000+1442527.000" Elevation="694" />
+    <Airport ICAO="YITT" FullName="Mitta Mitta" Position="-363044.000+1472122.000" Elevation="820" />
     <Airport ICAO="YIVE" FullName="Inverloch" Position="-383645.000+1454400.000" />
     <Airport ICAO="YIVG" FullName="Iveragh" Position="-240356.000+1512341.000" />
-    <Airport ICAO="YIVL" FullName="Inverell" Position="-295318.000+1510839.000">
+    <Airport ICAO="YIVL" FullName="Inverell" Position="-295318.000+1510839.000" Elevation="2669">
       <Runway Name="04" Position="-295333.160+1510816.140" />
       <Runway Name="22" Position="-295318.690+1510836.280" />
       <Runway Name="16" Position="-295243.040+1510836.510" />
       <Runway Name="34" Position="-295350.740+1510849.390" />
     </Airport>
-    <Airport ICAO="YIVO" FullName="Ivanhoe" Position="-325305.000+1441842.000">
+    <Airport ICAO="YIVO" FullName="Ivanhoe" Position="-325305.000+1441842.000" Elevation="332">
       <Runway Name="09" Position="-325254.380+1441822.690" />
       <Runway Name="27" Position="-325259.190+1441901.500" />
       <Runway Name="16" Position="-325252.600+1441837.950" />
       <Runway Name="34" Position="-325332.730+1441843.530" />
     </Airport>
-    <Airport ICAO="YJAB" FullName="Jabiru" Position="-123930.000+1325335.000">
+    <Airport ICAO="YJAB" FullName="Jabiru" Position="-123930.000+1325335.000" Elevation="85">
       <Runway Name="09" Position="-123927.030+1325317.610" />
       <Runway Name="27" Position="-123930.770+1325403.900" />
     </Airport>
-    <Airport ICAO="YJAC" FullName="Jacinth Ambrosia" Position="-305404.000+1321101.000">
+    <Airport ICAO="YJAC" FullName="Jacinth Ambrosia" Position="-305404.000+1321101.000" Elevation="419">
       <Runway Name="14" Position="-305341.330+1321039.100" />
       <Runway Name="32" Position="-305425.910+1321122.900" />
     </Airport>
     <Airport ICAO="YJBO" FullName="Jdandboo Field" Position="-375130.000+1465500.000" />
-    <Airport ICAO="YJBY" FullName="Jervis Bay" Position="-350851.000+1504155.000">
+    <Airport ICAO="YJBY" FullName="Jervis Bay" Position="-350851.000+1504155.000" Elevation="200">
       <Runway Name="08" Position="-350842.800+1504117.550" />
       <Runway Name="26" Position="-350846.840+1504215.140" />
       <Runway Name="15" Position="-350830.160+1504141.810" />
       <Runway Name="33" Position="-350917.690+1504158.450" />
     </Airport>
-    <Airport ICAO="YJDA" FullName="Jundah" Position="-244953.000+1430356.000" />
+    <Airport ICAO="YJDA" FullName="Jundah" Position="-244953.000+1430356.000" Elevation="476" />
     <Airport ICAO="YJDL" FullName="Jindalee" Position="-344937.000+1484729.000" />
-    <Airport ICAO="YJER" FullName="Jerilderie" Position="-352212.000+1454330.000" />
-    <Airport ICAO="YJIN" FullName="Jindabyne" Position="-362536.000+1483606.000" />
+    <Airport ICAO="YJER" FullName="Jerilderie" Position="-352212.000+1454330.000" Elevation="360" />
+    <Airport ICAO="YJIN" FullName="Jindabyne" Position="-362536.000+1483606.000" Elevation="3400" />
     <Airport ICAO="YJIP" FullName="Jingalup" Position="-335927.000+1165924.000" />
-    <Airport ICAO="YJLC" FullName="Julia Creek" Position="-204006.000+1414321.000">
+    <Airport ICAO="YJLC" FullName="Julia Creek" Position="-204006.000+1414321.000" Elevation="404">
       <Runway Name="10" Position="-203958.970+1414243.220" />
       <Runway Name="28" Position="-204012.430+1414329.470" />
     </Airport>
     <Airport ICAO="YJRK" FullName="Jarra Creek" Position="-175322.000+1454933.000" />
-    <Airport ICAO="YJST" FullName="Jamestown" Position="-331132.000+1383657.000" />
-    <Airport ICAO="YJUN" FullName="Jundee" Position="-262516.000+1203439.000">
+    <Airport ICAO="YJST" FullName="Jamestown" Position="-331132.000+1383657.000" Elevation="1550" />
+    <Airport ICAO="YJUN" FullName="Jundee" Position="-262516.000+1203439.000" Elevation="1845">
       <Runway Name="08" Position="-262522.640+1203402.870" />
       <Runway Name="26" Position="-262514.440+1203517.960" />
     </Airport>
-    <Airport ICAO="YJUR" FullName="Jurien Bay" Position="-301812.000+1150319.000" />
-    <Airport ICAO="YKAB" FullName="King Ash Bay" Position="-155552.000+1362855.000" />
-    <Airport ICAO="YKAL" FullName="Kalumburu" Position="-141717.000+1263752.000" />
-    <Airport ICAO="YKAR" FullName="Karara" Position="-291258.000+1164112.000">
+    <Airport ICAO="YJUR" FullName="Jurien Bay" Position="-301812.000+1150319.000" Elevation="50" />
+    <Airport ICAO="YKAB" FullName="King Ash Bay" Position="-155552.000+1362855.000" Elevation="30" />
+    <Airport ICAO="YKAL" FullName="Kalumburu" Position="-141717.000+1263752.000" Elevation="95" />
+    <Airport ICAO="YKAR" FullName="Karara" Position="-291258.000+1164112.000" Elevation="1019">
       <Runway Name="12" Position="-291251.890+1164050.610" />
       <Runway Name="30" Position="-291312.380+1164137.150" />
     </Airport>
     <Airport ICAO="YKAT" FullName="Katoomba" Position="-334006.000+1501924.000" />
-    <Airport ICAO="YKBL" FullName="Kambalda" Position="-311126.000+1213554.000">
+    <Airport ICAO="YKBL" FullName="Kambalda" Position="-311126.000+1213554.000" Elevation="1059">
       <Runway Name="16" Position="-311058.680+1213542.830" />
       <Runway Name="34" Position="-311154.800+1213601.810" />
     </Airport>
-    <Airport ICAO="YKBN" FullName="Kooralbyn" Position="-280524.000+1525027.000" />
-    <Airport ICAO="YKBR" FullName="Kalbarri" Position="-274131.000+1141534.000">
+    <Airport ICAO="YKBN" FullName="Kooralbyn" Position="-280524.000+1525027.000" Elevation="308" />
+    <Airport ICAO="YKBR" FullName="Kalbarri" Position="-274131.000+1141534.000" Elevation="515">
       <Runway Name="18" Position="-274105.950+1141533.320" />
       <Runway Name="36" Position="-274157.930+1141533.240" />
     </Airport>
     <Airport ICAO="YKBT" FullName="Kalabity Station" Position="-315502.000+1401908.000" />
-    <Airport ICAO="YKBY" FullName="Streaky Bay" Position="-325009.000+1341734.000">
+    <Airport ICAO="YKBY" FullName="Streaky Bay" Position="-325009.000+1341734.000" Elevation="69">
       <Runway Name="05" Position="-325040.300+1341737.340" />
       <Runway Name="23" Position="-325024.590+1341800.990" />
       <Runway Name="13" Position="-324957.190+1341713.820" />
       <Runway Name="31" Position="-325025.190+1341753.830" />
     </Airport>
     <Airport ICAO="YKCH" FullName="Kitchener" Position="-310136.000+1241100.000" />
-    <Airport ICAO="YKCS" FullName="Kings Creek Stn" Position="-242513.000+1314908.000" />
-    <Airport ICAO="YKCY" FullName="Kilcoy" Position="-265816.000+1523355.000" />
-    <Airport ICAO="YKDD" FullName="Gudai-Darri Mine" Position="-223019.000+1190434.000">
+    <Airport ICAO="YKCS" FullName="Kings Creek Stn" Position="-242513.000+1314908.000" Elevation="2017" />
+    <Airport ICAO="YKCY" FullName="Kilcoy" Position="-265816.000+1523355.000" Elevation="400" />
+    <Airport ICAO="YKDD" FullName="Gudai-Darri Mine" Position="-223019.000+1190434.000" Elevation="1473">
       <Runway Name="12" Position="-222959.930+1190402.020" />
       <Runway Name="30" Position="-223030.810+1190511.430" />
     </Airport>
-    <Airport ICAO="YKDI" FullName="Kadina" Position="-335812.000+1373936.000" />
-    <Airport ICAO="YKDM" FullName="Kidman Springs" Position="-160657.000+1305712.000" />
-    <Airport ICAO="YKDN" FullName="Kondinin" Position="-322803.000+1181611.000" />
+    <Airport ICAO="YKDI" FullName="Kadina" Position="-335812.000+1373936.000" Elevation="138" />
+    <Airport ICAO="YKDM" FullName="Kidman Springs" Position="-160657.000+1305712.000" Elevation="290" />
+    <Airport ICAO="YKDN" FullName="Kondinin" Position="-322803.000+1181611.000" Elevation="965" />
     <Airport ICAO="YKEN" FullName="Kenmore Park" Position="-262000.000+1322800.000" />
-    <Airport ICAO="YKEP" FullName="Lake Keepit" Position="-305324.000+1503136.000" />
-    <Airport ICAO="YKER" FullName="Kerang" Position="-354505.000+1435622.000">
+    <Airport ICAO="YKEP" FullName="Lake Keepit" Position="-305324.000+1503136.000" Elevation="1150" />
+    <Airport ICAO="YKER" FullName="Kerang" Position="-354505.000+1435622.000" Elevation="255">
       <Runway Name="05" Position="-354509.700+1435620.820" />
       <Runway Name="23" Position="-354458.120+1435644.410" />
       <Runway Name="14" Position="-354452.300+1435603.100" />
       <Runway Name="32" Position="-354521.950+1435624.990" />
     </Airport>
-    <Airport ICAO="YKHO" FullName="Kholo Helipad" Position="-272952.000+1524628.000" />
-    <Airport ICAO="YKID" FullName="Kidston" Position="-185215.000+1441024.000" />
-    <Airport ICAO="YKIG" FullName="Kingston" Position="-364912.000+1395212.000" />
-    <Airport ICAO="YKII" FullName="King Island" Position="-395239.000+1435242.000">
+    <Airport ICAO="YKHO" FullName="Kholo Helipad" Position="-272952.000+1524628.000" Elevation="220" />
+    <Airport ICAO="YKID" FullName="Kidston" Position="-185215.000+1441024.000" Elevation="1710" />
+    <Airport ICAO="YKIG" FullName="Kingston" Position="-364912.000+1395212.000" Elevation="8" />
+    <Airport ICAO="YKII" FullName="King Island" Position="-395239.000+1435242.000" Elevation="132">
       <Runway Name="10" Position="-395224.350+1435213.770" />
       <Runway Name="28" Position="-395245.650+1435314.450" />
       <Runway Name="17" Position="-395222.070+1435305.220" />
       <Runway Name="35" Position="-395257.840+1435301.800" />
     </Airport>
-    <Airport ICAO="YKKG" FullName="Kalkgurung" Position="-172555.000+1304829.000">
+    <Airport ICAO="YKKG" FullName="Kalkgurung" Position="-172555.000+1304829.000" Elevation="652">
       <Runway Name="03" Position="-172558.670+1304823.690" />
       <Runway Name="21" Position="-172524.760+1304847.100" />
       <Runway Name="13" Position="-172559.600+1304826.260" />
       <Runway Name="31" Position="-172621.650+1304849.130" />
     </Airport>
-    <Airport ICAO="YKKN" FullName="Kin Kin Retreat" Position="-342245.000+1161920.000" />
-    <Airport ICAO="YKLC" FullName="Koolan Island/Koolan Central" Position="-160733.000+1234405.000">
+    <Airport ICAO="YKKN" FullName="Kin Kin Retreat" Position="-342245.000+1161920.000" Elevation="400" />
+    <Airport ICAO="YKLC" FullName="Koolan Island/Koolan Central" Position="-160733.000+1234405.000" Elevation="540">
       <Runway Name="11" Position="-160715.800+1234334.330" />
       <Runway Name="29" Position="-160744.230+1234438.620" />
     </Airport>
-    <Airport ICAO="YKLE" FullName="Killarney" Position="-161501.000+1314449.000" />
-    <Airport ICAO="YKLI" FullName="Koolan Island/Koolan Village" Position="-160742.000+1234648.000" />
+    <Airport ICAO="YKLE" FullName="Killarney" Position="-161501.000+1314449.000" Elevation="636" />
+    <Airport ICAO="YKLI" FullName="Koolan Island/Koolan Village" Position="-160742.000+1234648.000" Elevation="495" />
     <Airport ICAO="YKLR" FullName="Kalamurina" Position="-274434.000+1381603.000" />
     <Airport ICAO="YKLS" FullName="Kailis" Position="-334600.000+1150233.000" />
-    <Airport ICAO="YKMB" FullName="Karumba" Position="-172720.000+1404954.000">
+    <Airport ICAO="YKMB" FullName="Karumba" Position="-172720.000+1404954.000" Elevation="18">
       <Runway Name="03" Position="-172722.560+1404948.130" />
       <Runway Name="21" Position="-172647.020+1405016.620" />
     </Airport>
-    <Airport ICAO="YKML" FullName="Kamileroi" Position="-192229.000+1400322.000" />
-    <Airport ICAO="YKMP" FullName="Kempsey" Position="-310428.000+1524611.000">
+    <Airport ICAO="YKML" FullName="Kamileroi" Position="-192229.000+1400322.000" Elevation="300" />
+    <Airport ICAO="YKMP" FullName="Kempsey" Position="-310428.000+1524611.000" Elevation="54">
       <Runway Name="04" Position="-310435.470+1524530.390" />
       <Runway Name="22" Position="-310404.390+1524620.800" />
     </Airport>
-    <Airport ICAO="YKNG" FullName="Katanning" Position="-334201.000+1173912.000">
+    <Airport ICAO="YKNG" FullName="Katanning" Position="-334201.000+1173912.000" Elevation="932">
       <Runway Name="07" Position="-334209.060+1173856.520" />
       <Runway Name="25" Position="-334148.900+1173949.560" />
       <Runway Name="13" Position="-334141.000+1173901.000" />
       <Runway Name="31" Position="-334159.900+1173927.800" />
     </Airport>
     <Airport ICAO="YKOO" FullName="Koolama Bay" Position="-135615.000+1271930.000" />
-    <Airport ICAO="YKOW" FullName="Kowanyama" Position="-152908.000+1414505.000">
+    <Airport ICAO="YKOW" FullName="Kowanyama" Position="-152908.000+1414505.000" Elevation="35">
       <Runway Name="12" Position="-152856.720+1414449.030" />
       <Runway Name="30" Position="-152919.130+1414529.150" />
     </Airport>
@@ -18307,13 +18323,13 @@ BOFOR
     <Airport ICAO="YKRK" FullName="Kirkalocka" Position="-284132.000+1174552.000" />
     <Airport ICAO="YKRL" FullName="Keeroongooloo" Position="-255421.000+1424812.000" />
     <Airport ICAO="YKRU" FullName="Mallowa/Krui" Position="-294023.000+1492715.000" />
-    <Airport ICAO="YKRY" FullName="Kingaroy" Position="-263451.000+1515028.000">
+    <Airport ICAO="YKRY" FullName="Kingaroy" Position="-263451.000+1515028.000" Elevation="1492">
       <Runway Name="05" Position="-263507.830+1515009.470" />
       <Runway Name="23" Position="-263450.080+1515052.220" />
       <Runway Name="16" Position="-263420.870+1515017.090" />
       <Runway Name="34" Position="-263511.910+1515028.050" />
     </Airport>
-    <Airport ICAO="YKSC" FullName="Kingscote/Kangaroo Island" Position="-354250.000+1373117.000">
+    <Airport ICAO="YKSC" FullName="Kingscote/Kangaroo Island" Position="-354250.000+1373117.000" Elevation="24">
       <Runway Name="01" Position="-354325.090+1373118.260" />
       <Runway Name="19" Position="-354230.250+1373144.540" />
       <Runway Name="06" Position="-354253.480+1373100.640" />
@@ -18321,116 +18337,116 @@ BOFOR
       <Runway Name="15" Position="-354233.680+1373104.460" />
       <Runway Name="33" Position="-354314.820+1373126.520" />
     </Airport>
-    <Airport ICAO="YKTH" FullName="Keith" Position="-360651.000+1401508.000" />
-    <Airport ICAO="YKTN" FullName="Kyneton" Position="-371332.000+1442649.000" />
+    <Airport ICAO="YKTH" FullName="Keith" Position="-360651.000+1401508.000" Elevation="92" />
+    <Airport ICAO="YKTN" FullName="Kyneton" Position="-371332.000+1442649.000" Elevation="1650" />
     <Airport ICAO="YKUA" FullName="South Talwood/Kulali" Position="-284021.000+1491134.000" />
-    <Airport ICAO="YKUB" FullName="Kubin" Position="-101336.000+1421325.000" />
+    <Airport ICAO="YKUB" FullName="Kubin" Position="-101336.000+1421325.000" Elevation="15" />
     <Airport ICAO="YKUK" FullName="Kukerin Airstrip" Position="-331030.000+1180454.000" />
     <Airport ICAO="YKUM" FullName="Kumbarilla/Ruby Jo" Position="-271346.000+1505219.000" />
     <Airport ICAO="YKUP" FullName="Kupunn" Position="-271137.000+1510648.000" />
     <Airport ICAO="YKUW" FullName="Kurweeton" Position="-380252.000+1430919.000" />
     <Airport ICAO="YKWG" FullName="Kangaroo Well" Position="-314706.000+1353818.000" />
     <Airport ICAO="YKYN" FullName="Kynuna" Position="-213600.000+1415500.000" />
-    <Airport ICAO="YLAH" FullName="Lawn Hill" Position="-183435.000+1383505.000" />
-    <Airport ICAO="YLAK" FullName="Lakeside Airpark" Position="-204106.000+1483730.000" />
-    <Airport ICAO="YLAW" FullName="Lawlers" Position="-280523.000+1203224.000" />
+    <Airport ICAO="YLAH" FullName="Lawn Hill" Position="-183435.000+1383505.000" Elevation="400" />
+    <Airport ICAO="YLAK" FullName="Lakeside Airpark" Position="-204106.000+1483730.000" Elevation="175" />
+    <Airport ICAO="YLAW" FullName="Lawlers" Position="-280523.000+1203224.000" Elevation="1598" />
     <Airport ICAO="YLBA" FullName="Belyando/Labona" Position="-220016.000+1462150.000" />
-    <Airport ICAO="YLBD" FullName="Djarindjin/Lombadina" Position="-163055.000+1225525.000">
+    <Airport ICAO="YLBD" FullName="Djarindjin/Lombadina" Position="-163055.000+1225525.000" Elevation="155">
       <Runway Name="10" Position="-163049.870+1225505.600" />
       <Runway Name="28" Position="-163100.400+1225544.570" />
     </Airport>
-    <Airport ICAO="YLCG" FullName="Lake Cargelligo" Position="-331642.000+1462209.000">
+    <Airport ICAO="YLCG" FullName="Lake Cargelligo" Position="-331642.000+1462209.000" Elevation="598">
       <Runway Name="05" Position="-331706.930+1462211.670" />
       <Runway Name="23" Position="-331649.030+1462252.930" />
       <Runway Name="12" Position="-331643.470+1462211.080" />
       <Runway Name="30" Position="-331702.090+1462236.890" />
     </Airport>
-    <Airport ICAO="YLCS" FullName="Locksley Field" Position="-364854.000+1452054.000" />
-    <Airport ICAO="YLEC" FullName="Leigh Creek" Position="-303554.000+1382533.000">
+    <Airport ICAO="YLCS" FullName="Locksley Field" Position="-364854.000+1452054.000" Elevation="540" />
+    <Airport ICAO="YLEC" FullName="Leigh Creek" Position="-303554.000+1382533.000" Elevation="856">
       <Runway Name="02" Position="-303613.490+1382513.160" />
       <Runway Name="20" Position="-303539.220+1382536.080" />
       <Runway Name="11" Position="-303544.390+1382527.190" />
       <Runway Name="29" Position="-303612.940+1382622.250" />
     </Airport>
-    <Airport ICAO="YLED" FullName="Lethbridge Airport" Position="-375508.000+1440604.000" />
-    <Airport ICAO="YLEG" FullName="Leongatha" Position="-382944.000+1455135.000" />
-    <Airport ICAO="YLEO" FullName="Leonora" Position="-285241.000+1211853.000">
+    <Airport ICAO="YLED" FullName="Lethbridge Airport" Position="-375508.000+1440604.000" Elevation="790" />
+    <Airport ICAO="YLEG" FullName="Leongatha" Position="-382944.000+1455135.000" Elevation="263" />
+    <Airport ICAO="YLEO" FullName="Leonora" Position="-285241.000+1211853.000" Elevation="1217">
       <Runway Name="04" Position="-285320.830+1211821.940" />
       <Runway Name="22" Position="-285228.320+1211906.510" />
       <Runway Name="12" Position="-285230.130+1211829.880" />
       <Runway Name="30" Position="-285255.930+1211901.070" />
     </Airport>
-    <Airport ICAO="YLEV" FullName="Lake Evella" Position="-122956.000+1354821.000">
+    <Airport ICAO="YLEV" FullName="Lake Evella" Position="-122956.000+1354821.000" Elevation="278">
       <Runway Name="08" Position="-122954.020+1354806.030" />
       <Runway Name="26" Position="-122951.280+1354841.190" />
     </Airport>
-    <Airport ICAO="YLGD" FullName="Longdown" Position="-414128.000+1470836.000" />
+    <Airport ICAO="YLGD" FullName="Longdown" Position="-414128.000+1470836.000" Elevation="521" />
     <Airport ICAO="YLGN" FullName="Loongana" Position="-305630.000+1270148.000" />
-    <Airport ICAO="YLGU" FullName="Legune Stn" Position="-151255.000+1292642.000" />
-    <Airport ICAO="YLHI" FullName="Lord Howe Island" Position="-313218.000+1590438.000">
+    <Airport ICAO="YLGU" FullName="Legune Stn" Position="-151255.000+1292642.000" Elevation="85" />
+    <Airport ICAO="YLHI" FullName="Lord Howe Island" Position="-313218.000+1590438.000" Elevation="17">
       <Runway Name="10" Position="-313212.260+1590418.150" />
       <Runway Name="28" Position="-313222.710+1590445.240" />
     </Airport>
     <Airport ICAO="YLHO" FullName="Lemington/Hunter Valley Operations" Position="-322805.000+1505859.000" />
-    <Airport ICAO="YLHR" FullName="Lockhart River" Position="-124713.000+1431817.000">
+    <Airport ICAO="YLHR" FullName="Lockhart River" Position="-124713.000+1431817.000" Elevation="77">
       <Runway Name="12" Position="-124701.450+1431802.130" />
       <Runway Name="30" Position="-124729.360+1431842.910" />
     </Airport>
     <Airport ICAO="YLIB" FullName="Fso Liberdade" Position="-110258.000+1263706.000" />
     <Airport ICAO="YLID" FullName="Liddell Coal" Position="-322320.000+1510012.000" />
     <Airport ICAO="YLIH" FullName="Lismore Hospital" Position="-284833.000+1531732.000" />
-    <Airport ICAO="YLIL" FullName="Lilydale" Position="-374131.000+1452159.000" />
+    <Airport ICAO="YLIL" FullName="Lilydale" Position="-374131.000+1452159.000" Elevation="242" />
     <Airport ICAO="YLIO" FullName="Liddell Open Cut Mine" Position="-322426.000+1510209.000" />
-    <Airport ICAO="YLIS" FullName="Lismore" Position="-284936.000+1531527.000">
+    <Airport ICAO="YLIS" FullName="Lismore" Position="-284936.000+1531527.000" Elevation="35">
       <Runway Name="15" Position="-284926.190+1531518.770" />
       <Runway Name="33" Position="-285015.790+1531542.550" />
     </Airport>
     <Airport ICAO="YLIV" FullName="Liveringa" Position="-175639.000+1241517.000" />
-    <Airport ICAO="YLJN" FullName="Lake Johnston" Position="-321904.000+1203317.000" />
-    <Airport ICAO="YLKE" FullName="Lakes Entrance" Position="-375108.000+1475655.000" />
+    <Airport ICAO="YLJN" FullName="Lake Johnston" Position="-321904.000+1203317.000" Elevation="1047" />
+    <Airport ICAO="YLKE" FullName="Lakes Entrance" Position="-375108.000+1475655.000" Elevation="220" />
     <Airport ICAO="YLKN" FullName="Lake Nash" Position="-205845.000+1375506.000" />
-    <Airport ICAO="YLKS" FullName="The Lakes" Position="-314253.000+1524329.000" />
-    <Airport ICAO="YLLE" FullName="Ballera" Position="-272430.000+1414830.000">
+    <Airport ICAO="YLKS" FullName="The Lakes" Position="-314253.000+1524329.000" Elevation="7" />
+    <Airport ICAO="YLLE" FullName="Ballera" Position="-272430.000+1414830.000" Elevation="385">
       <Runway Name="03" Position="-272442.980+1414812.780" />
       <Runway Name="21" Position="-272357.900+1414854.630" />
     </Airport>
-    <Airport ICAO="YLLT" FullName="Lower Light" Position="-343100.000+1382525.000" />
-    <Airport ICAO="YLMQ" FullName="Lake Macquarie Airport" Position="-330358.000+1513853.000" />
-    <Airport ICAO="YLMU" FullName="Mungo Lodge" Position="-334442.000+1430006.000" />
-    <Airport ICAO="YLND" FullName="Lakeland Downs" Position="-155009.000+1445051.000" />
+    <Airport ICAO="YLLT" FullName="Lower Light" Position="-343100.000+1382525.000" Elevation="55" />
+    <Airport ICAO="YLMQ" FullName="Lake Macquarie Airport" Position="-330358.000+1513853.000" Elevation="5" />
+    <Airport ICAO="YLMU" FullName="Mungo Lodge" Position="-334442.000+1430006.000" Elevation="270" />
+    <Airport ICAO="YLND" FullName="Lakeland Downs" Position="-155009.000+1445051.000" Elevation="781" />
     <Airport ICAO="YLNG" FullName="Prelude Flng" Position="-134710.000+1231850.000" />
-    <Airport ICAO="YLOH" FullName="Louth" Position="-303153.000+1450743.000" />
-    <Airport ICAO="YLOR" FullName="Lorraine" Position="-190023.000+1395358.000" />
-    <Airport ICAO="YLOV" FullName="Lotus Vale Stn" Position="-170254.000+1412235.000" />
+    <Airport ICAO="YLOH" FullName="Louth" Position="-303153.000+1450743.000" Elevation="350" />
+    <Airport ICAO="YLOR" FullName="Lorraine" Position="-190023.000+1395358.000" Elevation="165" />
+    <Airport ICAO="YLOV" FullName="Lotus Vale Stn" Position="-170254.000+1412235.000" Elevation="80" />
     <Airport ICAO="YLOW" FullName="Lowendal Island" Position="-203916.000+1153437.000" />
-    <Airport ICAO="YLOX" FullName="Loxton" Position="-342833.000+1403950.000" />
+    <Airport ICAO="YLOX" FullName="Loxton" Position="-342833.000+1403950.000" Elevation="125" />
     <Airport ICAO="YLPE" FullName="Leppington Pastoral East" Position="-335506.000+1504157.000" />
     <Airport ICAO="YLPW" FullName="Leppington Pastoral West" Position="-335527.000+1504059.000" />
-    <Airport ICAO="YLRD" FullName="Lightning Ridge" Position="-292724.000+1475904.000">
+    <Airport ICAO="YLRD" FullName="Lightning Ridge" Position="-292724.000+1475904.000" Elevation="540">
       <Runway Name="04" Position="-292718.470+1475850.220" />
       <Runway Name="22" Position="-292702.320+1475910.270" />
       <Runway Name="10" Position="-292701.980+1475811.410" />
       <Runway Name="28" Position="-292718.190+1475904.160" />
     </Airport>
-    <Airport ICAO="YLRE" FullName="Longreach" Position="-232603.000+1441649.000">
+    <Airport ICAO="YLRE" FullName="Longreach" Position="-232603.000+1441649.000" Elevation="627">
       <Runway Name="04" Position="-232616.760+1441614.430" />
       <Runway Name="22" Position="-232533.520+1441703.900" />
     </Airport>
     <Airport ICAO="YLSB" FullName="Lifever Base/Sydney" Position="-335940.000+1511458.000" />
     <Airport ICAO="YLSK" FullName="Luskintyre" Position="-323959.000+1512509.000" />
-    <Airport ICAO="YLST" FullName="Leinster" Position="-275036.000+1204212.000">
+    <Airport ICAO="YLST" FullName="Leinster" Position="-275036.000+1204212.000" Elevation="1631">
       <Runway Name="10" Position="-275033.690+1204142.580" />
       <Runway Name="28" Position="-275044.160+1204247.300" />
     </Airport>
     <Airport ICAO="YLSY" FullName="Mount Lindsay" Position="-270106.000+1295306.000" />
-    <Airport ICAO="YLTN" FullName="Laverton" Position="-283649.000+1222526.000">
+    <Airport ICAO="YLTN" FullName="Laverton" Position="-283649.000+1222526.000" Elevation="1530">
       <Runway Name="07" Position="-283700.240+1222515.950" />
       <Runway Name="25" Position="-283639.970+1222618.080" />
       <Runway Name="16" Position="-283622.930+1222521.740" />
       <Runway Name="34" Position="-283650.500+1222534.750" />
     </Airport>
     <Airport ICAO="YLTT" FullName="Lady Elliot Island" Position="-240648.000+1524256.000" />
-    <Airport ICAO="YLTV" FullName="Latrobe Valley" Position="-381226.000+1462813.000">
+    <Airport ICAO="YLTV" FullName="Latrobe Valley" Position="-381226.000+1462813.000" Elevation="180">
       <Runway Name="03" Position="-381255.890+1462754.190" />
       <Runway Name="21" Position="-381223.170+1462835.860" />
       <Runway Name="09" Position="-381218.400+1462755.330" />
@@ -18438,75 +18454,75 @@ BOFOR
     </Airport>
     <Airport ICAO="YLUL" FullName="Moolelulooloo" Position="-313800.000+1403100.000" />
     <Airport ICAO="YLWB" FullName="Lockyerters/Breefield" Position="-272814.000+1522317.000" />
-    <Airport ICAO="YLYK" FullName="Lyndoch" Position="-343718.000+1385451.000" />
-    <Airport ICAO="YLZI" FullName="Lizard Island" Position="-144022.000+1452715.000" />
-    <Airport ICAO="YMAA" FullName="Mabuiag Island" Position="-095706.000+1421147.000" />
+    <Airport ICAO="YLYK" FullName="Lyndoch" Position="-343718.000+1385451.000" Elevation="800" />
+    <Airport ICAO="YLZI" FullName="Lizard Island" Position="-144022.000+1452715.000" Elevation="70" />
+    <Airport ICAO="YMAA" FullName="Mabuiag Island" Position="-095706.000+1421147.000" Elevation="30" />
     <Airport ICAO="YMAC" FullName="Macumba" Position="-271542.000+1353818.000" />
-    <Airport ICAO="YMAE" FullName="Murray/Mer Island" Position="-095456.000+1440319.000" />
+    <Airport ICAO="YMAE" FullName="Murray/Mer Island" Position="-095456.000+1440319.000" Elevation="330" />
     <Airport ICAO="YMAR" FullName="Mataranka Township" Position="-145534.000+1330352.000" />
-    <Airport ICAO="YMAV" FullName="Avalon" Position="-380222.000+1442810.000">
+    <Airport ICAO="YMAV" FullName="Avalon" Position="-380222.000+1442810.000" Elevation="35">
       <Runway Name="18" Position="-380138.000+1442809.950" />
       <Runway Name="36" Position="-380315.980+1442753.440" />
     </Airport>
-    <Airport ICAO="YMAY" FullName="Albury" Position="-360404.000+1465729.000">
+    <Airport ICAO="YMAY" FullName="Albury" Position="-360404.000+1465729.000" Elevation="539">
       <Runway Name="07" Position="-360405.070+1465656.010" />
       <Runway Name="25" Position="-360355.620+1465811.070" />
     </Airport>
-    <Airport ICAO="YMBA" FullName="Mareeba" Position="-170414.000+1452526.000">
+    <Airport ICAO="YMBA" FullName="Mareeba" Position="-170414.000+1452526.000" Elevation="1564">
       <Runway Name="10" Position="-170404.440+1452502.230" />
       <Runway Name="28" Position="-170420.760+1452550.180" />
     </Airport>
-    <Airport ICAO="YMBD" FullName="Murray Bridge" Position="-350400.000+1391336.000" />
+    <Airport ICAO="YMBD" FullName="Murray Bridge" Position="-350400.000+1391336.000" Elevation="180" />
     <Airport ICAO="YMBG" FullName="Marlborough" Position="-224853.000+1495317.000" />
-    <Airport ICAO="YMBL" FullName="Marble Bar" Position="-210946.000+1195002.000" />
+    <Airport ICAO="YMBL" FullName="Marble Bar" Position="-210946.000+1195002.000" Elevation="637" />
     <Airport ICAO="YMBO" FullName="Marmboo" Position="-231800.000+1432700.000" />
-    <Airport ICAO="YMBT" FullName="Mount Beauty" Position="-364400.000+1471000.000" />
-    <Airport ICAO="YMBU" FullName="Maryborough (Vic)" Position="-370159.000+1434232.000" />
+    <Airport ICAO="YMBT" FullName="Mount Beauty" Position="-364400.000+1471000.000" Elevation="1100" />
+    <Airport ICAO="YMBU" FullName="Maryborough (Vic)" Position="-370159.000+1434232.000" Elevation="766" />
     <Airport ICAO="YMCF" FullName="Mccaffrey Field" Position="-272057.000+1513050.000" />
     <Airport ICAO="YMCK" FullName="Mckinlay" Position="-211600.000+1411800.000" />
-    <Airport ICAO="YMCL" FullName="Mount Coolon" Position="-212313.000+1471956.000" />
+    <Airport ICAO="YMCL" FullName="Mount Coolon" Position="-212313.000+1471956.000" Elevation="785" />
     <Airport ICAO="YMCM" FullName="Mangoola Coal Mine" Position="-321743.000+1504229.000" />
-    <Airport ICAO="YMCO" FullName="Mallacoota" Position="-373556.000+1494315.000">
+    <Airport ICAO="YMCO" FullName="Mallacoota" Position="-373556.000+1494315.000" Elevation="102">
       <Runway Name="07" Position="-373604.800+1494250.350" />
       <Runway Name="25" Position="-373601.300+1494325.990" />
       <Runway Name="18" Position="-373539.190+1494320.530" />
       <Runway Name="36" Position="-373611.970+1494312.620" />
     </Airport>
     <Airport ICAO="YMCR" FullName="Manners Creek Stn" Position="-220600.000+1375900.000" />
-    <Airport ICAO="YMCT" FullName="Millicent" Position="-373501.000+1402158.000" />
-    <Airport ICAO="YMDA" FullName="Mundubbera" Position="-253556.000+1511908.000" />
-    <Airport ICAO="YMDG" FullName="Mudgee" Position="-323345.000+1493640.000">
+    <Airport ICAO="YMCT" FullName="Millicent" Position="-373501.000+1402158.000" Elevation="56" />
+    <Airport ICAO="YMDA" FullName="Mundubbera" Position="-253556.000+1511908.000" Elevation="400" />
+    <Airport ICAO="YMDG" FullName="Mudgee" Position="-323345.000+1493640.000" Elevation="1545">
       <Runway Name="04" Position="-323411.040+1493607.290" />
       <Runway Name="22" Position="-323336.400+1493659.890" />
       <Runway Name="16" Position="-323318.370+1493640.930" />
       <Runway Name="34" Position="-323352.880+1493647.470" />
     </Airport>
     <Airport ICAO="YMDK" FullName="Mount Riddock Stn" Position="-230200.000+1344100.000" />
-    <Airport ICAO="YMDN" FullName="Merredin" Position="-313124.000+1181912.000" />
-    <Airport ICAO="YMDR" FullName="Minderoo" Position="-215936.000+1150242.000" />
+    <Airport ICAO="YMDN" FullName="Merredin" Position="-313124.000+1181912.000" Elevation="1300" />
+    <Airport ICAO="YMDR" FullName="Minderoo" Position="-215936.000+1150242.000" Elevation="50" />
     <Airport ICAO="YMDV" FullName="Mount Davies" Position="-261024.000+1290748.000" />
-    <Airport ICAO="YMDY" FullName="Mount Bundey" Position="-125324.000+1315426.000" />
+    <Airport ICAO="YMDY" FullName="Mount Bundey" Position="-125324.000+1315426.000" Elevation="150" />
     <Airport ICAO="YMEB" FullName="Mount Eba" Position="-301043.000+1354025.000" />
     <Airport ICAO="YMED" FullName="Menindee" Position="-322200.000+1422418.000" />
-    <Airport ICAO="YMEI" FullName="Mereenie" Position="-235836.000+1313342.000" />
-    <Airport ICAO="YMEK" FullName="Meekatharra" Position="-263642.000+1183252.000">
+    <Airport ICAO="YMEI" FullName="Mereenie" Position="-235836.000+1313342.000" Elevation="2410" />
+    <Airport ICAO="YMEK" FullName="Meekatharra" Position="-263642.000+1183252.000" Elevation="1713">
       <Runway Name="09" Position="-263632.790+1183206.400" />
       <Runway Name="27" Position="-263626.490+1183324.920" />
       <Runway Name="15" Position="-263633.660+1183256.470" />
       <Runway Name="33" Position="-263659.790+1183321.720" />
     </Airport>
-    <Airport ICAO="YMEL" FullName="Melton" Position="-373718.000+1443356.000" />
-    <Airport ICAO="YMEN" FullName="Melbourne/Essendon" Position="-374341.000+1445407.000">
+    <Airport ICAO="YMEL" FullName="Melton" Position="-373718.000+1443356.000" Elevation="670" />
+    <Airport ICAO="YMEN" FullName="Melbourne/Essendon" Position="-374341.000+1445407.000" Elevation="282">
       <Runway Name="08" Position="-374352.970+1445334.390" />
       <Runway Name="26" Position="-374350.840+1445452.800" />
       <Runway Name="17" Position="-374313.490+1445402.740" />
       <Runway Name="35" Position="-374402.200+1445405.080" />
     </Airport>
-    <Airport ICAO="YMER" FullName="Merimbula" Position="-365431.000+1495405.000">
+    <Airport ICAO="YMER" FullName="Merimbula" Position="-365431.000+1495405.000" Elevation="8">
       <Runway Name="03" Position="-365446.300+1495347.710" />
       <Runway Name="21" Position="-365403.210+1495423.890" />
     </Airport>
-    <Airport ICAO="YMES" FullName="Eastle" Position="-380556.000+1470858.000">
+    <Airport ICAO="YMES" FullName="Eastle" Position="-380556.000+1470858.000" Elevation="23">
       <Runway Name="04" Position="-380621.780+1470818.820" />
       <Runway Name="22" Position="-380535.170+1470939.620" />
       <Runway Name="09" Position="-380544.450+1470741.880" />
@@ -18514,55 +18530,55 @@ BOFOR
     </Airport>
     <Airport ICAO="YMET" FullName="Melvilleter Aerodrome" Position="-315839.000+1155029.000" />
     <Airport ICAO="YMFA" FullName="Missen Flat/Auburnvale" Position="-275444.000+1515707.000" />
-    <Airport ICAO="YMFD" FullName="Mansfield" Position="-370400.000+1460700.000" />
-    <Airport ICAO="YMGB" FullName="Milingimbi" Position="-120540.000+1345337.000">
+    <Airport ICAO="YMFD" FullName="Mansfield" Position="-370400.000+1460700.000" Elevation="1050" />
+    <Airport ICAO="YMGB" FullName="Milingimbi" Position="-120540.000+1345337.000" Elevation="53">
       <Runway Name="11" Position="-120531.580+1345314.410" />
       <Runway Name="29" Position="-120551.860+1345356.260" />
     </Airport>
-    <Airport ICAO="YMGD" FullName="Maningrida" Position="-120322.000+1341403.000">
+    <Airport ICAO="YMGD" FullName="Maningrida" Position="-120322.000+1341403.000" Elevation="123">
       <Runway Name="14" Position="-120309.360+1341357.660" />
       <Runway Name="32" Position="-120351.820+1341423.950" />
     </Airport>
     <Airport ICAO="YMGG" FullName="Mulgathing" Position="-301345.000+1335910.000" />
-    <Airport ICAO="YMGI" FullName="Mungindi" Position="-285802.000+1490313.000" />
-    <Airport ICAO="YMGR" FullName="Margaret River Stn" Position="-183717.000+1265302.000" />
-    <Airport ICAO="YMGT" FullName="Margaret River" Position="-335550.000+1150600.000" />
-    <Airport ICAO="YMHB" FullName="Hobart" Position="-425010.000+1473037.000">
+    <Airport ICAO="YMGI" FullName="Mungindi" Position="-285802.000+1490313.000" Elevation="600" />
+    <Airport ICAO="YMGR" FullName="Margaret River Stn" Position="-183717.000+1265302.000" Elevation="949" />
+    <Airport ICAO="YMGT" FullName="Margaret River" Position="-335550.000+1150600.000" Elevation="374" />
+    <Airport ICAO="YMHB" FullName="Hobart" Position="-425010.000+1473037.000" Elevation="13">
       <Runway Name="12" Position="-424944.300+1473007.380" />
       <Runway Name="30" Position="-425044.080+1473128.550" />
     </Airport>
-    <Airport ICAO="YMHL" FullName="Mount Holland" Position="-320706.000+1194606.000" />
-    <Airport ICAO="YMHO" FullName="Mount House" Position="-170304.000+1254248.000" />
-    <Airport ICAO="YMHU" FullName="Mcarthur River Mine" Position="-162636.000+1360436.000">
+    <Airport ICAO="YMHL" FullName="Mount Holland" Position="-320706.000+1194606.000" Elevation="1476" />
+    <Airport ICAO="YMHO" FullName="Mount House" Position="-170304.000+1254248.000" Elevation="948" />
+    <Airport ICAO="YMHU" FullName="Mcarthur River Mine" Position="-162636.000+1360436.000" Elevation="136">
       <Runway Name="06" Position="-162655.480+1360351.010" />
       <Runway Name="24" Position="-162626.740+1360509.850" />
     </Airport>
-    <Airport ICAO="YMHW" FullName="Mount Howitt" Position="-263040.000+1421700.000" />
-    <Airport ICAO="YMIA" FullName="Mildura" Position="-341345.000+1420508.000">
+    <Airport ICAO="YMHW" FullName="Mount Howitt" Position="-263040.000+1421700.000" Elevation="345" />
+    <Airport ICAO="YMIA" FullName="Mildura" Position="-341345.000+1420508.000" Elevation="167">
       <Runway Name="09" Position="-341335.110+1420425.900" />
       <Runway Name="27" Position="-341347.080+1420535.950" />
       <Runway Name="18" Position="-341333.000+1420522.800" />
       <Runway Name="36" Position="-341409.830+1420518.880" />
     </Airport>
-    <Airport ICAO="YMIG" FullName="Mittagong" Position="-342654.000+1503012.000" />
+    <Airport ICAO="YMIG" FullName="Mittagong" Position="-342654.000+1503012.000" Elevation="1840" />
     <Airport ICAO="YMIK" FullName="Millers Creek" Position="-295636.000+1360636.000" />
     <Airport ICAO="YMIN" FullName="Minlaton" Position="-344438.000+1373144.000" />
-    <Airport ICAO="YMIO" FullName="Mill Iron" Position="-231926.000+1504145.000" />
+    <Airport ICAO="YMIO" FullName="Mill Iron" Position="-231926.000+1504145.000" Elevation="150" />
     <Airport ICAO="YMIP" FullName="Mitchell Plateau" Position="-144725.000+1254933.000" />
-    <Airport ICAO="YMIT" FullName="Mitchell" Position="-262900.000+1475612.000" />
-    <Airport ICAO="YMJM" FullName="Manjimup" Position="-341555.000+1160825.000">
+    <Airport ICAO="YMIT" FullName="Mitchell" Position="-262900.000+1475612.000" Elevation="1134" />
+    <Airport ICAO="YMJM" FullName="Manjimup" Position="-341555.000+1160825.000" Elevation="940">
       <Runway Name="12" Position="-341547.730+1160802.920" />
       <Runway Name="30" Position="-341603.860+1160846.640" />
     </Airport>
     <Airport ICAO="YMKA" FullName="Mataranka Hs Resort" Position="-145548.000+1330800.000" />
-    <Airport ICAO="YMKT" FullName="Emkaytee" Position="-123636.000+1310310.000" />
-    <Airport ICAO="YMLD" FullName="Maitland (Sa)" Position="-342334.000+1374226.000" />
+    <Airport ICAO="YMKT" FullName="Emkaytee" Position="-123636.000+1310310.000" Elevation="80" />
+    <Airport ICAO="YMLD" FullName="Maitland (Sa)" Position="-342334.000+1374226.000" Elevation="559" />
     <Airport ICAO="YMLL" FullName="Millungera" Position="-195139.000+1413403.000" />
-    <Airport ICAO="YMLS" FullName="Miles" Position="-264822.000+1501011.000">
+    <Airport ICAO="YMLS" FullName="Miles" Position="-264822.000+1501011.000" Elevation="1002">
       <Runway Name="04" Position="-264840.170+1500945.580" />
       <Runway Name="22" Position="-264807.070+1501029.730" />
     </Airport>
-    <Airport ICAO="YMLT" FullName="Launceston" Position="-413243.000+1471251.000">
+    <Airport ICAO="YMLT" FullName="Launceston" Position="-413243.000+1471251.000" Elevation="562">
       <Runway Name="14L" Position="-413228.330+1471251.660" />
       <Runway Name="32R" Position="-413247.620+1471307.570" />
       <Runway Name="14R" Position="-413213.440+1471214.750" />
@@ -18570,7 +18586,7 @@ BOFOR
       <Runway Name="18" Position="-413221.620+1471303.780" />
       <Runway Name="36" Position="-413243.100+1471255.460" />
     </Airport>
-    <Airport ICAO="YMMB" FullName="Melbourne/Moorabbin" Position="-375833.000+1450608.000">
+    <Airport ICAO="YMMB" FullName="Melbourne/Moorabbin" Position="-375833.000+1450608.000" Elevation="55">
       <Runway Name="04" Position="-375846.270+1450553.260" />
       <Runway Name="22" Position="-375835.940+1450607.440" />
       <Runway Name="13L" Position="-375822.470+1450555.120" />
@@ -18584,21 +18600,21 @@ BOFOR
     </Airport>
     <Airport ICAO="YMMD" FullName="Dixalea/Mcmaster Field" Position="-235713.000+1501619.000" />
     <Airport ICAO="YMMH" FullName="Mount Mulgrave Hs" Position="-162300.000+1435900.000" />
-    <Airport ICAO="YMMI" FullName="Murrin Murrin" Position="-284219.000+1215326.000">
+    <Airport ICAO="YMMI" FullName="Murrin Murrin" Position="-284219.000+1215326.000" Elevation="1535">
       <Runway Name="03" Position="-284244.690+1215303.550" />
       <Runway Name="21" Position="-284151.590+1215346.050" />
     </Airport>
-    <Airport ICAO="YMML" FullName="Melbourne" Position="-374024.000+1445036.000">
+    <Airport ICAO="YMML" FullName="Melbourne" Position="-374024.000+1445036.000" Elevation="434">
       <Runway Name="09" Position="-373938.700+1444920.110" />
       <Runway Name="27" Position="-373944.120+1445053.130" />
       <Runway Name="16" Position="-373911.450+1445005.690" />
       <Runway Name="34" Position="-374108.800+1445027.600" />
     </Airport>
-    <Airport ICAO="YMMN" FullName="Millmerran" Position="-275148.000+1511630.000" />
-    <Airport ICAO="YMMO" FullName="Moama" Position="-360428.000+1444552.000" />
+    <Airport ICAO="YMMN" FullName="Millmerran" Position="-275148.000+1511630.000" Elevation="1312" />
+    <Airport ICAO="YMMO" FullName="Moama" Position="-360428.000+1444552.000" Elevation="310" />
     <Airport ICAO="YMMR" FullName="Mandemar" Position="-342641.000+1501723.000" />
-    <Airport ICAO="YMMU" FullName="Middlemount" Position="-224809.000+1484217.000" />
-    <Airport ICAO="YMND" FullName="Maitland (NSW)" Position="-324215.000+1512920.000">
+    <Airport ICAO="YMMU" FullName="Middlemount" Position="-224809.000+1484217.000" Elevation="547" />
+    <Airport ICAO="YMND" FullName="Maitland (NSW)" Position="-324215.000+1512920.000" Elevation="95">
       <Runway Name="05" Position="-324211.240+1512922.390" />
       <Runway Name="23" Position="-324151.140+1512958.580" />
       <Runway Name="08" Position="-324204.190+1512927.090" />
@@ -18606,41 +18622,41 @@ BOFOR
       <Runway Name="18" Position="-324146.230+1512935.680" />
       <Runway Name="36" Position="-324202.130+1512931.320" />
     </Airport>
-    <Airport ICAO="YMNE" FullName="Mount Keith" Position="-271711.000+1203317.000">
+    <Airport ICAO="YMNE" FullName="Mount Keith" Position="-271711.000+1203317.000" Elevation="1792">
       <Runway Name="11" Position="-271701.310+1203244.790" />
       <Runway Name="29" Position="-271725.140+1203344.590" />
     </Airport>
-    <Airport ICAO="YMNG" FullName="Mangalore" Position="-365318.000+1451103.000">
+    <Airport ICAO="YMNG" FullName="Mangalore" Position="-365318.000+1451103.000" Elevation="467">
       <Runway Name="05" Position="-365336.470+1451022.720" />
       <Runway Name="23" Position="-365257.880+1451128.960" />
       <Runway Name="18" Position="-365257.980+1451124.000" />
       <Runway Name="36" Position="-365344.750+1451114.690" />
     </Airport>
-    <Airport ICAO="YMNK" FullName="Monkira" Position="-244907.000+1403312.000" />
+    <Airport ICAO="YMNK" FullName="Monkira" Position="-244907.000+1403312.000" Elevation="350" />
     <Airport ICAO="YMNN" FullName="Mount Denison" Position="-220827.000+1320409.000" />
     <Airport ICAO="YMNP" FullName="Murnpeowie" Position="-293535.000+1390301.000" />
     <Airport ICAO="YMNT" FullName="Mornington Stn" Position="-173120.000+1260724.000" />
     <Airport ICAO="YMNU" FullName="Mainoru" Position="-140301.000+1340550.000" />
-    <Airport ICAO="YMNY" FullName="Morney" Position="-252130.000+1412600.000" />
-    <Airport ICAO="YMOD" FullName="Modewarre" Position="-381538.000+1440531.000" />
+    <Airport ICAO="YMNY" FullName="Morney" Position="-252130.000+1412600.000" Elevation="340" />
+    <Airport ICAO="YMOD" FullName="Modewarre" Position="-381538.000+1440531.000" Elevation="420" />
     <Airport ICAO="YMOE" FullName="Moonaree" Position="-315759.000+1355231.000" />
-    <Airport ICAO="YMOG" FullName="Mount Magnet" Position="-280658.000+1175030.000">
+    <Airport ICAO="YMOG" FullName="Mount Magnet" Position="-280658.000+1175030.000" Elevation="1354">
       <Runway Name="04" Position="-280704.050+1175006.520" />
       <Runway Name="22" Position="-280640.260+1175025.680" />
       <Runway Name="16" Position="-280627.940+1175013.410" />
       <Runway Name="34" Position="-280721.690+1175039.300" />
     </Airport>
     <Airport ICAO="YMOO" FullName="Mooraberree" Position="-251438.000+1405838.000" />
-    <Airport ICAO="YMOR" FullName="Moree" Position="-292956.000+1495041.000">
+    <Airport ICAO="YMOR" FullName="Moree" Position="-292956.000+1495041.000" Elevation="701">
       <Runway Name="01" Position="-293022.620+1495034.950" />
       <Runway Name="19" Position="-292932.710+1495052.700" />
       <Runway Name="05" Position="-293003.000+1495011.650" />
       <Runway Name="23" Position="-292946.240+1495042.510" />
     </Airport>
-    <Airport ICAO="YMOU" FullName="Moura" Position="-243642.000+1495947.000" />
+    <Airport ICAO="YMOU" FullName="Moura" Position="-243642.000+1495947.000" Elevation="482" />
     <Airport ICAO="YMOX" FullName="Moxey Farms" Position="-333101.000+1482111.000" />
-    <Airport ICAO="YMPA" FullName="Minnipa" Position="-325035.000+1350840.000" />
-    <Airport ICAO="YMPC" FullName="Point Cook" Position="-375556.000+1444512.000">
+    <Airport ICAO="YMPA" FullName="Minnipa" Position="-325035.000+1350840.000" Elevation="509" />
+    <Airport ICAO="YMPC" FullName="Point Cook" Position="-375556.000+1444512.000" Elevation="14">
       <Runway Name="04" Position="-375611.020+1444447.350" />
       <Runway Name="22" Position="-375546.400+1444521.940" />
       <Runway Name="08" Position="-375603.660+1444450.940" />
@@ -18649,29 +18665,29 @@ BOFOR
       <Runway Name="35" Position="-375611.400+1444516.820" />
     </Airport>
     <Airport ICAO="YMPY" FullName="Mount Perry" Position="-251100.000+1513900.000" />
-    <Airport ICAO="YMRB" FullName="Moranbah" Position="-220328.000+1480439.000">
+    <Airport ICAO="YMRB" FullName="Moranbah" Position="-220328.000+1480439.000" Elevation="770">
       <Runway Name="16" Position="-220304.840+1480430.930" />
       <Runway Name="34" Position="-220353.920+1480438.920" />
     </Airport>
-    <Airport ICAO="YMRE" FullName="Marree" Position="-293946.000+1380357.000" />
-    <Airport ICAO="YMRG" FullName="Murgon" Position="-261510.000+1515548.000" />
+    <Airport ICAO="YMRE" FullName="Marree" Position="-293946.000+1380357.000" Elevation="164" />
+    <Airport ICAO="YMRG" FullName="Murgon" Position="-261510.000+1515548.000" Elevation="1025" />
     <Airport ICAO="YMRR" FullName="Moore Reef" Position="-165312.000+1461124.000" />
     <Airport ICAO="YMRT" FullName="Mount Garnet" Position="-174200.000+1450900.000" />
-    <Airport ICAO="YMRW" FullName="Morawa" Position="-291205.000+1160119.000">
+    <Airport ICAO="YMRW" FullName="Morawa" Position="-291205.000+1160119.000" Elevation="902">
       <Runway Name="09" Position="-291209.280+1160111.160" />
       <Runway Name="27" Position="-291208.830+1160147.250" />
       <Runway Name="15" Position="-291149.840+1160105.750" />
       <Runway Name="33" Position="-291227.280+1160131.730" />
     </Airport>
-    <Airport ICAO="YMRY" FullName="Moruya" Position="-355352.000+1500840.000">
+    <Airport ICAO="YMRY" FullName="Moruya" Position="-355352.000+1500840.000" Elevation="19">
       <Runway Name="04" Position="-355413.510+1500823.720" />
       <Runway Name="22" Position="-355358.540+1500851.110" />
       <Runway Name="18" Position="-355319.780+1500853.920" />
       <Runway Name="36" Position="-355408.180+1500841.490" />
     </Airport>
-    <Airport ICAO="YMSF" FullName="Mountnford Station" Position="-165842.000+1303318.000" />
-    <Airport ICAO="YMTB" FullName="Muttaburra" Position="-223500.000+1443200.000" />
-    <Airport ICAO="YMTG" FullName="Mount Gambier" Position="-374444.000+1404707.000">
+    <Airport ICAO="YMSF" FullName="Mountnford Station" Position="-165842.000+1303318.000" Elevation="759" />
+    <Airport ICAO="YMTB" FullName="Muttaburra" Position="-223500.000+1443200.000" Elevation="753" />
+    <Airport ICAO="YMTG" FullName="Mount Gambier" Position="-374444.000+1404707.000" Elevation="212">
       <Runway Name="06" Position="-374458.080+1404646.750" />
       <Runway Name="24" Position="-374445.960+1404717.780" />
       <Runway Name="11" Position="-374445.500+1404646.380" />
@@ -18679,40 +18695,40 @@ BOFOR
       <Runway Name="18" Position="-374425.080+1404722.910" />
       <Runway Name="36" Position="-374518.150+1404716.160" />
     </Airport>
-    <Airport ICAO="YMTI" FullName="Mornington Island" Position="-163945.000+1391041.000">
+    <Airport ICAO="YMTI" FullName="Mornington Island" Position="-163945.000+1391041.000" Elevation="33">
       <Runway Name="09" Position="-163937.850+1390946.830" />
       <Runway Name="27" Position="-163945.030+1391037.490" />
     </Airport>
     <Airport ICAO="YMTJ" FullName="Montejinni" Position="-164217.000+1314403.000" />
-    <Airport ICAO="YMTO" FullName="Monto" Position="-245332.000+1510607.000" />
+    <Airport ICAO="YMTO" FullName="Monto" Position="-245332.000+1510607.000" Elevation="757" />
     <Airport ICAO="YMTU" FullName="Moonie/Tungamah Station" Position="-273741.000+1502932.000" />
     <Airport ICAO="YMTX" FullName="Mount Dare Stn" Position="-260342.000+1351448.000" />
-    <Airport ICAO="YMUL" FullName="Murray Field" Position="-323037.000+1155000.000">
+    <Airport ICAO="YMUL" FullName="Murray Field" Position="-323037.000+1155000.000" Elevation="56">
       <Runway Name="05" Position="-323032.320+1154954.900" />
       <Runway Name="23" Position="-323006.270+1155026.170" />
       <Runway Name="09" Position="-323034.270+1154948.170" />
       <Runway Name="27" Position="-323034.310+1155022.790" />
     </Airport>
-    <Airport ICAO="YMUR" FullName="Murwillumbah" Position="-281952.000+1532449.000" />
+    <Airport ICAO="YMUR" FullName="Murwillumbah" Position="-281952.000+1532449.000" Elevation="18" />
     <Airport ICAO="YMUZ" FullName="Mount Mulligan Lodge" Position="-165155.000+1445246.000" />
     <Airport ICAO="YMVM" FullName="Mangrove Mt" Position="-331706.000+1511242.000" />
     <Airport ICAO="YMVN" FullName="Morven" Position="-262400.000+1470724.000" />
     <Airport ICAO="YMVT" FullName="Montara Venture Fpso" Position="-123935.000+1243234.000" />
-    <Airport ICAO="YMWA" FullName="Mullewa" Position="-282831.000+1153103.000" />
+    <Airport ICAO="YMWA" FullName="Mullewa" Position="-282831.000+1153103.000" Elevation="950" />
     <Airport ICAO="YMWD" FullName="Holmwood" Position="-365929.000+1401501.000" />
     <Airport ICAO="YMWH" FullName="Montara Whp" Position="-124020.000+1243222.000" />
     <Airport ICAO="YMWO" FullName="Mahanewo" Position="-314306.000+1362600.000" />
-    <Airport ICAO="YMYB" FullName="Maryborough (Qld)" Position="-253048.000+1524254.000">
+    <Airport ICAO="YMYB" FullName="Maryborough (Qld)" Position="-253048.000+1524254.000" Elevation="38">
       <Runway Name="12" Position="-253042.430+1524242.140" />
       <Runway Name="30" Position="-253100.400+1524306.970" />
       <Runway Name="17" Position="-253022.970+1524245.770" />
       <Runway Name="35" Position="-253114.240+1524252.180" />
     </Airport>
     <Airport ICAO="YMYH" FullName="Mallapunyah Springs Stn" Position="-165800.000+1354636.000" />
-    <Airport ICAO="YMYU" FullName="Myrup" Position="-334722.000+1215725.000" />
-    <Airport ICAO="YNAN" FullName="Nanango" Position="-264130.000+1515912.000" />
-    <Airport ICAO="YNAP" FullName="Nappa Merrie" Position="-273330.000+1410800.000" />
-    <Airport ICAO="YNAR" FullName="Narrandera" Position="-344208.000+1463044.000">
+    <Airport ICAO="YMYU" FullName="Myrup" Position="-334722.000+1215725.000" Elevation="30" />
+    <Airport ICAO="YNAN" FullName="Nanango" Position="-264130.000+1515912.000" Elevation="1190" />
+    <Airport ICAO="YNAP" FullName="Nappa Merrie" Position="-273330.000+1410800.000" Elevation="180" />
+    <Airport ICAO="YNAR" FullName="Narrandera" Position="-344208.000+1463044.000" Elevation="474">
       <Runway Name="05" Position="-344212.800+1463033.060" />
       <Runway Name="23" Position="-344155.290+1463101.430" />
       <Runway Name="14" Position="-344136.000+1463019.780" />
@@ -18720,7 +18736,7 @@ BOFOR
     </Airport>
     <Airport ICAO="YNAT" FullName="Nathan River Stn" Position="-153513.000+1352548.000" />
     <Airport ICAO="YNBO" FullName="Nebo" Position="-214208.000+1484140.000" />
-    <Airport ICAO="YNBR" FullName="Narrabri" Position="-301909.000+1494938.000">
+    <Airport ICAO="YNBR" FullName="Narrabri" Position="-301909.000+1494938.000" Elevation="788">
       <Runway Name="09" Position="-301848.420+1494928.800" />
       <Runway Name="27" Position="-301852.260+1495013.990" />
       <Runway Name="18" Position="-301850.830+1494939.490" />
@@ -18730,15 +18746,15 @@ BOFOR
     <Airport ICAO="YNEN" FullName="Northern Endeavour" Position="-103724.000+1260200.000" />
     <Airport ICAO="YNER" FullName="Nerrima" Position="-183018.000+1242350.000" />
     <Airport ICAO="YNEW" FullName="Newlands Coal" Position="-211018.000+1475432.000" />
-    <Airport ICAO="YNEY" FullName="Nelly Bay" Position="-190943.000+1465113.000" />
+    <Airport ICAO="YNEY" FullName="Nelly Bay" Position="-190943.000+1465113.000" Elevation="10" />
     <Airport ICAO="YNGM" FullName="Nangram/Windibri" Position="-265233.000+1501840.000" />
-    <Airport ICAO="YNGU" FullName="Ngukurr" Position="-144322.000+1344451.000">
+    <Airport ICAO="YNGU" FullName="Ngukurr" Position="-144322.000+1344451.000" Elevation="45">
       <Runway Name="11" Position="-144313.990+1344428.640" />
       <Runway Name="29" Position="-144334.590+1344515.190" />
     </Airport>
     <Airport ICAO="YNGV" FullName="Ningaloo Vision Fpso" Position="-212406.000+1140512.000" />
-    <Airport ICAO="YNGW" FullName="Nagambie-Wirrate" Position="-364702.000+1450213.000" />
-    <Airport ICAO="YNHL" FullName="Nhill" Position="-361840.000+1413840.000">
+    <Airport ICAO="YNGW" FullName="Nagambie-Wirrate" Position="-364702.000+1450213.000" Elevation="475" />
+    <Airport ICAO="YNHL" FullName="Nhill" Position="-361840.000+1413840.000" Elevation="454">
       <Runway Name="09" Position="-361835.250+1413829.690" />
       <Runway Name="27" Position="-361842.270+1413908.850" />
       <Runway Name="18" Position="-361825.300+1413837.790" />
@@ -18746,152 +18762,152 @@ BOFOR
     </Airport>
     <Airport ICAO="YNHV" FullName="New Haven" Position="-224343.000+1310852.000" />
     <Airport ICAO="YNJY" FullName="Ngujima-Yin Floating" Position="-212555.000+1140412.000" />
-    <Airport ICAO="YNKR" FullName="Nackeroo" Position="-153436.000+1302830.000" />
+    <Airport ICAO="YNKR" FullName="Nackeroo" Position="-153436.000+1302830.000" Elevation="439" />
     <Airport ICAO="YNOM" FullName="Norman Reef" Position="-162530.000+1455923.000" />
-    <Airport ICAO="YNOV" FullName="Nova" Position="-315043.000+1231131.000">
+    <Airport ICAO="YNOV" FullName="Nova" Position="-315043.000+1231131.000" Elevation="962">
       <Runway Name="06" Position="-315100.960+1231058.870" />
       <Runway Name="24" Position="-315029.370+1231205.330" />
     </Airport>
     <Airport ICAO="YNPA" FullName="Nilpinna" Position="-282900.000+1355400.000" />
-    <Airport ICAO="YNPE" FullName="Northern Peninsula" Position="-105703.000+1422734.000">
+    <Airport ICAO="YNPE" FullName="Northern Peninsula" Position="-105703.000+1422734.000" Elevation="34">
       <Runway Name="13" Position="-105618.220+1422652.280" />
       <Runway Name="31" Position="-105702.070+1422733.250" />
     </Airport>
-    <Airport ICAO="YNRB" FullName="Narembeen" Position="-320700.000+1182500.000" />
-    <Airport ICAO="YNRC" FullName="Naracoorte" Position="-365907.000+1404330.000">
+    <Airport ICAO="YNRB" FullName="Narembeen" Position="-320700.000+1182500.000" Elevation="1000" />
+    <Airport ICAO="YNRC" FullName="Naracoorte" Position="-365907.000+1404330.000" Elevation="169">
       <Runway Name="02" Position="-365923.910+1404322.950" />
       <Runway Name="20" Position="-365845.350+1404347.760" />
       <Runway Name="08" Position="-365851.200+1404302.210" />
       <Runway Name="26" Position="-365847.690+1404344.270" />
     </Airport>
-    <Airport ICAO="YNRG" FullName="Narrogin" Position="-325548.000+1170448.000" />
-    <Airport ICAO="YNRH" FullName="Newcastle Regional Heliport" Position="-325246.000+1514343.000" />
+    <Airport ICAO="YNRG" FullName="Narrogin" Position="-325548.000+1170448.000" Elevation="1080" />
+    <Airport ICAO="YNRH" FullName="Newcastle Regional Heliport" Position="-325246.000+1514343.000" Elevation="24" />
     <Airport ICAO="YNRL" FullName="Naryilco" Position="-283300.000+1415500.000" />
-    <Airport ICAO="YNRM" FullName="Narromine" Position="-321252.000+1481329.000">
+    <Airport ICAO="YNRM" FullName="Narromine" Position="-321252.000+1481329.000" Elevation="782">
       <Runway Name="04" Position="-321304.640+1481317.880" />
       <Runway Name="22" Position="-321245.210+1481349.080" />
       <Runway Name="11" Position="-321244.300+1481303.710" />
       <Runway Name="29" Position="-321305.650+1481344.890" />
     </Airport>
     <Airport ICAO="YNRR" FullName="Nyirripi" Position="-223842.000+1303354.000" />
-    <Airport ICAO="YNRV" FullName="Ravensthorpe" Position="-334750.000+1201229.000">
+    <Airport ICAO="YNRV" FullName="Ravensthorpe" Position="-334750.000+1201229.000" Elevation="209">
       <Runway Name="06" Position="-334806.600+1201201.700" />
       <Runway Name="24" Position="-334738.400+1201257.600" />
       <Runway Name="14" Position="-334736.300+1201224.800" />
       <Runway Name="32" Position="-334805.500+1201255.500" />
     </Airport>
-    <Airport ICAO="YNSH" FullName="Noosa" Position="-262524.000+1530348.000" />
-    <Airport ICAO="YNSM" FullName="Norseman" Position="-321234.000+1214516.000" />
-    <Airport ICAO="YNTH" FullName="Normanton Helipad" Position="-174039.000+1410406.000" />
-    <Airport ICAO="YNTM" FullName="Northam" Position="-313733.000+1164104.000" />
-    <Airport ICAO="YNTN" FullName="Normanton" Position="-174106.000+1410413.000">
+    <Airport ICAO="YNSH" FullName="Noosa" Position="-262524.000+1530348.000" Elevation="3" />
+    <Airport ICAO="YNSM" FullName="Norseman" Position="-321234.000+1214516.000" Elevation="866" />
+    <Airport ICAO="YNTH" FullName="Normanton Helipad" Position="-174039.000+1410406.000" Elevation="70" />
+    <Airport ICAO="YNTM" FullName="Northam" Position="-313733.000+1164104.000" Elevation="500" />
+    <Airport ICAO="YNTN" FullName="Normanton" Position="-174106.000+1410413.000" Elevation="73">
       <Runway Name="14" Position="-174050.960+1410402.920" />
       <Runway Name="32" Position="-174136.450+1410434.310" />
     </Airport>
-    <Airport ICAO="YNUB" FullName="Nullarbor Motel" Position="-312628.000+1305408.000" />
+    <Airport ICAO="YNUB" FullName="Nullarbor Motel" Position="-312628.000+1305408.000" Elevation="220" />
     <Airport ICAO="YNUE" FullName="Numery" Position="-235950.000+1352517.000" />
-    <Airport ICAO="YNUL" FullName="Nullagine" Position="-215446.000+1201155.000" />
-    <Airport ICAO="YNUM" FullName="Numbulwar" Position="-141618.000+1354300.000">
+    <Airport ICAO="YNUL" FullName="Nullagine" Position="-215446.000+1201155.000" Elevation="1251" />
+    <Airport ICAO="YNUM" FullName="Numbulwar" Position="-141618.000+1354300.000" Elevation="31">
       <Runway Name="15" Position="-141551.810+1354241.790" />
       <Runway Name="33" Position="-141628.880+1354304.140" />
     </Airport>
-    <Airport ICAO="YNWN" FullName="Newman" Position="-232504.000+1194810.000">
+    <Airport ICAO="YNWN" FullName="Newman" Position="-232504.000+1194810.000" Elevation="1724">
       <Runway Name="05" Position="-232525.540+1194740.730" />
       <Runway Name="23" Position="-232447.690+1194841.130" />
     </Airport>
-    <Airport ICAO="YNYN" FullName="Nyngan" Position="-313304.000+1471210.000">
+    <Airport ICAO="YNYN" FullName="Nyngan" Position="-313304.000+1471210.000" Elevation="569">
       <Runway Name="05" Position="-313315.880+1471143.980" />
       <Runway Name="23" Position="-313248.670+1471237.510" />
       <Runway Name="18" Position="-313240.570+1471203.060" />
       <Runway Name="36" Position="-313314.110+1471153.670" />
     </Airport>
     <Airport ICAO="YNYP" FullName="Nyapari" Position="-261116.000+1301132.000" />
-    <Airport ICAO="YOAS" FullName="The Oaks" Position="-340502.000+1503337.000" />
-    <Airport ICAO="YOAY" FullName="Oaky Creek" Position="-230335.000+1482941.000" />
-    <Airport ICAO="YOCA" FullName="Ochre Arch" Position="-334521.000+1480046.000" />
+    <Airport ICAO="YOAS" FullName="The Oaks" Position="-340502.000+1503337.000" Elevation="880" />
+    <Airport ICAO="YOAY" FullName="Oaky Creek" Position="-230335.000+1482941.000" Elevation="581" />
+    <Airport ICAO="YOCA" FullName="Ochre Arch" Position="-334521.000+1480046.000" Elevation="1059" />
     <Airport ICAO="YOCC" FullName="Oak Creek Coal" Position="-230323.000+1482944.000" />
     <Airport ICAO="YOCM" FullName="Mt Owen Coal Mine" Position="-322341.000+1510529.000" />
-    <Airport ICAO="YOEH" FullName="Orange East Heliport" Position="-331902.000+1490853.000" />
-    <Airport ICAO="YOEN" FullName="Oenpelli" Position="-121931.000+1330020.000">
+    <Airport ICAO="YOEH" FullName="Orange East Heliport" Position="-331902.000+1490853.000" Elevation="2828" />
+    <Airport ICAO="YOEN" FullName="Oenpelli" Position="-121931.000+1330020.000" Elevation="30">
       <Runway Name="12" Position="-121921.230+1330005.410" />
       <Runway Name="30" Position="-121941.870+1330043.730" />
     </Airport>
     <Airport ICAO="YOKA" FullName="Okha Oil Rig Fpso" Position="-193530.000+1162606.000" />
-    <Airport ICAO="YOLA" FullName="Colac" Position="-381711.000+1434047.000" />
-    <Airport ICAO="YOLD" FullName="Olympic Dam" Position="-302906.000+1365236.000">
+    <Airport ICAO="YOLA" FullName="Colac" Position="-381711.000+1434047.000" Elevation="450" />
+    <Airport ICAO="YOLD" FullName="Olympic Dam" Position="-302906.000+1365236.000" Elevation="344">
       <Runway Name="07" Position="-302912.640+1365200.740" />
       <Runway Name="25" Position="-302852.490+1365306.480" />
     </Airport>
-    <Airport ICAO="YOLW" FullName="Onslow" Position="-214006.000+1150647.000">
+    <Airport ICAO="YOLW" FullName="Onslow" Position="-214006.000+1150647.000" Elevation="23">
       <Runway Name="03" Position="-214043.710+1150634.670" />
       <Runway Name="21" Position="-213949.920+1150707.170" />
     </Airport>
-    <Airport ICAO="YOOD" FullName="Oodnadatta" Position="-273336.000+1352642.000" />
-    <Airport ICAO="YOOM" FullName="Moomba" Position="-280558.000+1401149.000">
+    <Airport ICAO="YOOD" FullName="Oodnadatta" Position="-273336.000+1352642.000" Elevation="386" />
+    <Airport ICAO="YOOM" FullName="Moomba" Position="-280558.000+1401149.000" Elevation="143">
       <Runway Name="12" Position="-280539.420+1401126.270" />
       <Runway Name="30" Position="-280612.820+1401216.680" />
     </Airport>
-    <Airport ICAO="YORB" FullName="Orbost" Position="-374725.000+1483635.000">
+    <Airport ICAO="YORB" FullName="Orbost" Position="-374725.000+1483635.000" Elevation="93">
       <Runway Name="07" Position="-374724.700+1483618.560" />
       <Runway Name="25" Position="-374720.140+1483704.800" />
     </Airport>
-    <Airport ICAO="YORG" FullName="Orange" Position="-332241.000+1490732.000">
+    <Airport ICAO="YORG" FullName="Orange" Position="-332241.000+1490732.000" Elevation="3112">
       <Runway Name="04" Position="-332238.790+1490721.260" />
       <Runway Name="22" Position="-332223.370+1490745.320" />
       <Runway Name="11" Position="-332228.890+1490708.640" />
       <Runway Name="29" Position="-332310.590+1490818.340" />
     </Airport>
     <Airport ICAO="YORO" FullName="Moroak" Position="-144900.000+1334200.000" />
-    <Airport ICAO="YORR" FullName="Orroroo" Position="-324730.000+1384000.000" />
-    <Airport ICAO="YOSB" FullName="Osborne Mine" Position="-220454.000+1403324.000">
+    <Airport ICAO="YORR" FullName="Orroroo" Position="-324730.000+1384000.000" Elevation="1354" />
+    <Airport ICAO="YOSB" FullName="Osborne Mine" Position="-220454.000+1403324.000" Elevation="935">
       <Runway Name="12" Position="-220432.430+1403259.970" />
       <Runway Name="30" Position="-220515.780+1403352.000" />
     </Airport>
     <Airport ICAO="YOSI" FullName="Osborne Islands" Position="-142131.000+1260100.000" />
-    <Airport ICAO="YPAC" FullName="Pacific Haven" Position="-251412.000+1523236.000" />
-    <Airport ICAO="YPAD" FullName="Adelaide" Position="-345642.000+1383150.000">
+    <Airport ICAO="YPAC" FullName="Pacific Haven" Position="-251412.000+1523236.000" Elevation="30" />
+    <Airport ICAO="YPAD" FullName="Adelaide" Position="-345642.000+1383150.000" Elevation="20">
       <Runway Name="05" Position="-345727.540+1383106.500" />
       <Runway Name="23" Position="-345626.230+1383235.750" />
       <Runway Name="12" Position="-345628.170+1383118.900" />
       <Runway Name="30" Position="-345657.770+1383213.190" />
     </Airport>
-    <Airport ICAO="YPAG" FullName="Port Augusta" Position="-323025.000+1374300.000">
+    <Airport ICAO="YPAG" FullName="Port Augusta" Position="-323025.000+1374300.000" Elevation="56">
       <Runway Name="15" Position="-322953.130+1374240.830" />
       <Runway Name="33" Position="-323043.220+1374303.200" />
     </Airport>
-    <Airport ICAO="YPAM" FullName="Palm Island" Position="-184519.000+1463453.000">
+    <Airport ICAO="YPAM" FullName="Palm Island" Position="-184519.000+1463453.000" Elevation="30">
       <Runway Name="14" Position="-184503.880+1463441.220" />
       <Runway Name="32" Position="-184532.920+1463504.480" />
     </Airport>
     <Airport ICAO="YPAN" FullName="Pandora" Position="-231918.000+1502148.000" />
     <Airport ICAO="YPAR" FullName="Port Arthur" Position="-430616.000+1475133.000" />
-    <Airport ICAO="YPAY" FullName="Papunya" Position="-231428.000+1315425.000" />
-    <Airport ICAO="YPBH" FullName="Peterborough/Great Ocean Road" Position="-383624.000+1425422.000">
+    <Airport ICAO="YPAY" FullName="Papunya" Position="-231428.000+1315425.000" Elevation="2035" />
+    <Airport ICAO="YPBH" FullName="Peterborough/Great Ocean Road" Position="-383624.000+1425422.000" Elevation="111">
       <Runway Name="08" Position="-383624.450+1425355.520" />
       <Runway Name="26" Position="-383627.230+1425442.590" />
     </Airport>
     <Airport ICAO="YPBM" FullName="Port Bremmer" Position="-111326.000+1321603.000" />
     <Airport ICAO="YPBN" FullName="Port Broughton" Position="-333555.000+1375605.000" />
-    <Airport ICAO="YPBO" FullName="Paraburdoo" Position="-231016.000+1174443.000">
+    <Airport ICAO="YPBO" FullName="Paraburdoo" Position="-231016.000+1174443.000" Elevation="1406">
       <Runway Name="06" Position="-231031.580+1174414.960" />
       <Runway Name="24" Position="-231002.490+1174523.010" />
     </Airport>
-    <Airport ICAO="YPCC" FullName="Cocos (Keeling) Islands" Position="-121119.000+0964950.000">
+    <Airport ICAO="YPCC" FullName="Cocos (Keeling) Islands" Position="-121119.000+0964950.000" Elevation="10">
       <Runway Name="15" Position="-121054.700+0964940.630" />
       <Runway Name="33" Position="-121202.950+0965021.960" />
     </Airport>
-    <Airport ICAO="YPCE" FullName="Pooncarie" Position="-332223.000+1423505.000">
+    <Airport ICAO="YPCE" FullName="Pooncarie" Position="-332223.000+1423505.000" Elevation="153">
       <Runway Name="06" Position="-332231.330+1423452.940" />
       <Runway Name="24" Position="-332216.200+1423529.490" />
     </Airport>
     <Airport ICAO="YPCH" FullName="Patchewollock" Position="-352300.000+1421200.000" />
-    <Airport ICAO="YPDN" FullName="Darwin" Position="-122453.000+1305236.000">
+    <Airport ICAO="YPDN" FullName="Darwin" Position="-122453.000+1305236.000" Elevation="103">
       <Runway Name="11" Position="-122433.850+1305154.940" />
       <Runway Name="29" Position="-122509.220+1305339.990" />
       <Runway Name="18" Position="-122431.830+1305214.350" />
       <Runway Name="36" Position="-122521.450+1305214.480" />
     </Airport>
-    <Airport ICAO="YPEA" FullName="Pearce" Position="-314004.000+1160054.000">
+    <Airport ICAO="YPEA" FullName="Pearce" Position="-314004.000+1160054.000" Elevation="150">
       <Runway Name="05" Position="-314020.350+1160031.290" />
       <Runway Name="23" Position="-313941.350+1160116.470" />
       <Runway Name="18L" Position="-313944.680+1160049.370" />
@@ -18899,26 +18915,26 @@ BOFOR
       <Runway Name="18R" Position="-314007.610+1160048.000" />
       <Runway Name="36L" Position="-314103.800+1160055.480" />
     </Airport>
-    <Airport ICAO="YPED" FullName="Edinburgh" Position="-344209.000+1383715.000">
+    <Airport ICAO="YPED" FullName="Edinburgh" Position="-344209.000+1383715.000" Elevation="67">
       <Runway Name="18" Position="-344140.330+1383703.300" />
       <Runway Name="36" Position="-344302.470+1383648.400" />
     </Airport>
-    <Airport ICAO="YPEF" FullName="Penfield" Position="-373048.000+1444154.000" />
+    <Airport ICAO="YPEF" FullName="Penfield" Position="-373048.000+1444154.000" Elevation="1150" />
     <Airport ICAO="YPEP" FullName="Peppimenarti" Position="-140839.000+1300526.000" />
     <Airport ICAO="YPER" FullName="Braidwood/Percheron" Position="-352037.000+1495459.000" />
     <Airport ICAO="YPFL" FullName="Preston Field" Position="-330112.000+1154206.000" />
-    <Airport ICAO="YPFT" FullName="Cooma-Polo Flat" Position="-361345.000+1490858.000" />
+    <Airport ICAO="YPFT" FullName="Cooma-Polo Flat" Position="-361345.000+1490858.000" Elevation="2701" />
     <Airport ICAO="YPGH" FullName="Pigeon Hole" Position="-164900.000+1311300.000" />
-    <Airport ICAO="YPGV" FullName="Gove" Position="-121610.000+1364906.000">
+    <Airport ICAO="YPGV" FullName="Gove" Position="-121610.000+1364906.000" Elevation="205">
       <Runway Name="13" Position="-121546.260+1364835.200" />
       <Runway Name="31" Position="-121632.370+1364931.230" />
     </Airport>
-    <Airport ICAO="YPHP" FullName="Port Campbell Heliport" Position="-383744.000+1430226.000" />
+    <Airport ICAO="YPHP" FullName="Port Campbell Heliport" Position="-383744.000+1430226.000" Elevation="250" />
     <Airport ICAO="YPHS" FullName="Anmatjere/Pine Hill Station" Position="-222313.000+1330337.000" />
     <Airport ICAO="YPIC" FullName="Piccaninny" Position="-193700.000+1463150.000" />
-    <Airport ICAO="YPID" FullName="Phillip Island Heliport" Position="-383112.000+1451936.000" />
+    <Airport ICAO="YPID" FullName="Phillip Island Heliport" Position="-383112.000+1451936.000" Elevation="43" />
     <Airport ICAO="YPIN" FullName="Pinnacle" Position="-154000.000+1433300.000" />
-    <Airport ICAO="YPIR" FullName="Port Pirie" Position="-331420.000+1375942.000">
+    <Airport ICAO="YPIR" FullName="Port Pirie" Position="-331420.000+1375942.000" Elevation="39">
       <Runway Name="03" Position="-331427.710+1375952.720" />
       <Runway Name="21" Position="-331411.440+1380010.050" />
       <Runway Name="08" Position="-331417.200+1375928.260" />
@@ -18926,7 +18942,7 @@ BOFOR
       <Runway Name="17" Position="-331406.330+1375929.250" />
       <Runway Name="35" Position="-331441.050+1375928.870" />
     </Airport>
-    <Airport ICAO="YPJT" FullName="Perth/Jandakot" Position="-320551.000+1155252.000">
+    <Airport ICAO="YPJT" FullName="Perth/Jandakot" Position="-320551.000+1155252.000" Elevation="99">
       <Runway Name="06L" Position="-320559.920+1155228.540" />
       <Runway Name="24R" Position="-320538.610+1155303.530" />
       <Runway Name="06R" Position="-320603.170+1155236.980" />
@@ -18934,33 +18950,33 @@ BOFOR
       <Runway Name="12" Position="-320559.810+1155220.950" />
       <Runway Name="30" Position="-320620.090+1155313.280" />
     </Airport>
-    <Airport ICAO="YPKA" FullName="Karratha" Position="-204244.000+1164624.000">
+    <Airport ICAO="YPKA" FullName="Karratha" Position="-204244.000+1164624.000" Elevation="33">
       <Runway Name="08" Position="-204250.490+1164552.960" />
       <Runway Name="26" Position="-204242.290+1164711.300" />
     </Airport>
-    <Airport ICAO="YPKG" FullName="Kalgoorlie-Boulder" Position="-304722.000+1212742.000">
+    <Airport ICAO="YPKG" FullName="Kalgoorlie-Boulder" Position="-304722.000+1212742.000" Elevation="1203">
       <Runway Name="11" Position="-304717.830+1212716.610" />
       <Runway Name="29" Position="-304740.520+1212827.100" />
       <Runway Name="18" Position="-304653.120+1212743.610" />
       <Runway Name="36" Position="-304731.900+1212739.310" />
     </Airport>
-    <Airport ICAO="YPKL" FullName="Puckapunyal" Position="-365958.000+1450346.000" />
-    <Airport ICAO="YPKS" FullName="Parkes" Position="-330753.000+1481421.000">
+    <Airport ICAO="YPKL" FullName="Puckapunyal" Position="-365958.000+1450346.000" Elevation="550" />
+    <Airport ICAO="YPKS" FullName="Parkes" Position="-330753.000+1481421.000" Elevation="1069">
       <Runway Name="04" Position="-330814.030+1481350.060" />
       <Runway Name="22" Position="-330742.590+1481443.250" />
       <Runway Name="11" Position="-330729.250+1481349.090" />
       <Runway Name="29" Position="-330756.130+1481435.040" />
     </Airport>
-    <Airport ICAO="YPKT" FullName="Port Keats" Position="-141500.000+1293145.000">
+    <Airport ICAO="YPKT" FullName="Port Keats" Position="-141500.000+1293145.000" Elevation="111">
       <Runway Name="16" Position="-141437.360+1293138.410" />
       <Runway Name="34" Position="-141520.730+1293153.740" />
     </Airport>
-    <Airport ICAO="YPKU" FullName="Kununurra" Position="-154641.000+1284227.000">
+    <Airport ICAO="YPKU" FullName="Kununurra" Position="-154641.000+1284227.000" Elevation="145">
       <Runway Name="12" Position="-154625.890+1284206.050" />
       <Runway Name="30" Position="-154655.330+1284259.430" />
     </Airport>
     <Airport ICAO="YPLA" FullName="Pluto Alpha" Position="-195946.000+1152207.000" />
-    <Airport ICAO="YPLC" FullName="Port Lincoln" Position="-343619.000+1355249.000">
+    <Airport ICAO="YPLC" FullName="Port Lincoln" Position="-343619.000+1355249.000" Elevation="36">
       <Runway Name="01" Position="-343645.390+1355235.890" />
       <Runway Name="19" Position="-343558.770+1355252.720" />
       <Runway Name="05" Position="-343626.540+1355229.890" />
@@ -18968,45 +18984,45 @@ BOFOR
       <Runway Name="15" Position="-343556.690+1355230.740" />
       <Runway Name="33" Position="-343638.960+1355255.780" />
     </Airport>
-    <Airport ICAO="YPLM" FullName="Learmonth" Position="-221408.000+1140519.000">
+    <Airport ICAO="YPLM" FullName="Learmonth" Position="-221408.000+1140519.000" Elevation="19">
       <Runway Name="18" Position="-221311.890+1140528.150" />
       <Runway Name="36" Position="-221450.730+1140520.980" />
     </Airport>
     <Airport ICAO="YPLS" FullName="Gladstone/Playstation" Position="-310238.000+1525610.000" />
-    <Airport ICAO="YPLU" FullName="Plutonic" Position="-251900.000+1192524.000">
+    <Airport ICAO="YPLU" FullName="Plutonic" Position="-251900.000+1192524.000" Elevation="1896">
       <Runway Name="07" Position="-251914.920+1192450.750" />
       <Runway Name="25" Position="-251847.600+1192558.290" />
     </Airport>
-    <Airport ICAO="YPMH" FullName="Prominent Hill" Position="-294304.000+1353128.000">
+    <Airport ICAO="YPMH" FullName="Prominent Hill" Position="-294304.000+1353128.000" Elevation="741">
       <Runway Name="18" Position="-294222.100+1353134.710" />
       <Runway Name="36" Position="-294332.550+1353120.860" />
     </Airport>
-    <Airport ICAO="YPMP" FullName="Pormpuraaw" Position="-145351.000+1413639.000">
+    <Airport ICAO="YPMP" FullName="Pormpuraaw" Position="-145351.000+1413639.000" Elevation="11">
       <Runway Name="14" Position="-145327.760+1413621.930" />
       <Runway Name="32" Position="-145406.310+1413644.290" />
     </Airport>
-    <Airport ICAO="YPMQ" FullName="Port Macquarie" Position="-312609.000+1525148.000">
+    <Airport ICAO="YPMQ" FullName="Port Macquarie" Position="-312609.000+1525148.000" Elevation="15">
       <Runway Name="03" Position="-312634.640+1525125.890" />
       <Runway Name="21" Position="-312543.880+1525159.730" />
     </Airport>
-    <Airport ICAO="YPNA" FullName="Pinnarendi" Position="-180218.000+1445300.000" />
+    <Airport ICAO="YPNA" FullName="Pinnarendi" Position="-180218.000+1445300.000" Elevation="2450" />
     <Airport ICAO="YPND" FullName="Pentland" Position="-203200.000+1452200.000" />
-    <Airport ICAO="YPNN" FullName="Pinnaroo" Position="-351530.000+1405641.000" />
+    <Airport ICAO="YPNN" FullName="Pinnaroo" Position="-351530.000+1405641.000" Elevation="330" />
     <Airport ICAO="YPOA" FullName="Portia Gold Mine" Position="-312546.000+1402529.000" />
-    <Airport ICAO="YPOD" FullName="Portland" Position="-381905.000+1412816.000">
+    <Airport ICAO="YPOD" FullName="Portland" Position="-381905.000+1412816.000" Elevation="266">
       <Runway Name="08" Position="-381910.220+1412745.900" />
       <Runway Name="26" Position="-381907.850+1412852.410" />
       <Runway Name="17" Position="-381849.330+1412758.290" />
       <Runway Name="35" Position="-381927.570+1412800.490" />
     </Airport>
-    <Airport ICAO="YPOK" FullName="Porepunkah" Position="-364304.000+1465324.000" />
-    <Airport ICAO="YPPD" FullName="Port Hedland" Position="-202240.000+1183735.000">
+    <Airport ICAO="YPOK" FullName="Porepunkah" Position="-364304.000+1465324.000" Elevation="935" />
+    <Airport ICAO="YPPD" FullName="Port Hedland" Position="-202240.000+1183735.000" Elevation="33">
       <Runway Name="14" Position="-202226.710+1183717.760" />
       <Runway Name="32" Position="-202326.580+1183816.080" />
       <Runway Name="18" Position="-202213.030+1183745.460" />
       <Runway Name="36" Position="-202245.490+1183744.010" />
     </Airport>
-    <Airport ICAO="YPPF" FullName="Adelaide/Parafield" Position="-344736.000+1383759.000">
+    <Airport ICAO="YPPF" FullName="Adelaide/Parafield" Position="-344736.000+1383759.000" Elevation="57">
       <Runway Name="03L" Position="-344813.520+1383750.300" />
       <Runway Name="21R" Position="-344734.960+1383815.420" />
       <Runway Name="03R" Position="-344807.730+1383803.610" />
@@ -19016,7 +19032,7 @@ BOFOR
       <Runway Name="08R" Position="-344744.010+1383723.930" />
       <Runway Name="26L" Position="-344741.090+1383802.790" />
     </Airport>
-    <Airport ICAO="YPPH" FullName="Perth" Position="-315625.000+1155801.000">
+    <Airport ICAO="YPPH" FullName="Perth" Position="-315625.000+1155801.000" Elevation="67">
       <Runway Name="03" Position="-315731.460+1155734.860" />
       <Runway Name="21" Position="-315542.940+1155806.470" />
       <Runway Name="06" Position="-315627.560+1155733.130" />
@@ -19028,22 +19044,22 @@ BOFOR
     <Airport ICAO="YPRV" FullName="Pascoe River" Position="-123326.000+1430718.000" />
     <Airport ICAO="YPSI" FullName="Passage Island" Position="-403000.000+1482000.000" />
     <Airport ICAO="YPSR" FullName="Perisher" Position="-362419.000+1482453.000" />
-    <Airport ICAO="YPTB" FullName="Peterborough" Position="-330018.000+1385054.000" />
+    <Airport ICAO="YPTB" FullName="Peterborough" Position="-330018.000+1385054.000" Elevation="1838" />
     <Airport ICAO="YPTG" FullName="Port George" Position="-152300.000+1244000.000" />
-    <Airport ICAO="YPTN" FullName="Tindal" Position="-143116.000+1322240.000">
+    <Airport ICAO="YPTN" FullName="Tindal" Position="-143116.000+1322240.000" Elevation="443">
       <Runway Name="14" Position="-143043.910+1322207.890" />
       <Runway Name="32" Position="-143151.160+1322308.100" />
     </Airport>
     <Airport ICAO="YPTT" FullName="Pernatty" Position="-312900.000+1372900.000" />
     <Airport ICAO="YPUA" FullName="Palumpa" Position="-142022.000+1295152.000" />
-    <Airport ICAO="YPUG" FullName="Pungalina" Position="-164319.000+1372524.000" />
+    <Airport ICAO="YPUG" FullName="Pungalina" Position="-164319.000+1372524.000" Elevation="80" />
     <Airport ICAO="YPUK" FullName="Puk Puk" Position="-192640.000+1462440.000" />
-    <Airport ICAO="YPWH" FullName="Pittsworth" Position="-274400.000+1513800.000" />
-    <Airport ICAO="YPWR" FullName="Woomera" Position="-310839.000+1364901.000">
+    <Airport ICAO="YPWH" FullName="Pittsworth" Position="-274400.000+1513800.000" Elevation="1690" />
+    <Airport ICAO="YPWR" FullName="Woomera" Position="-310839.000+1364901.000" Elevation="549">
       <Runway Name="18" Position="-310806.440+1364849.930" />
       <Runway Name="36" Position="-310923.080+1364840.850" />
     </Airport>
-    <Airport ICAO="YPXM" FullName="Christmas Island" Position="-102702.000+1054125.000">
+    <Airport ICAO="YPXM" FullName="Christmas Island" Position="-102702.000+1054125.000" Elevation="913">
       <Runway Name="18" Position="-102626.810+1054124.800" />
       <Runway Name="36" Position="-102735.020+1054130.450" />
     </Airport>
@@ -19051,94 +19067,94 @@ BOFOR
     <Airport ICAO="YPYV" FullName="Pyrenees Venture" Position="-213221.000+1140655.000" />
     <Airport ICAO="YQCI" FullName="Curtis Island/Qclng" Position="-234600.000+1511137.000" />
     <Airport ICAO="YQDG" FullName="Quairading" Position="-320024.000+1172454.000" />
-    <Airport ICAO="YQDI" FullName="Quirindi" Position="-312955.000+1503105.000">
+    <Airport ICAO="YQDI" FullName="Quirindi" Position="-312955.000+1503105.000" Elevation="1058">
       <Runway Name="06" Position="-313005.390+1503047.590" />
       <Runway Name="24" Position="-312950.460+1503125.700" />
       <Runway Name="14" Position="-312927.120+1503051.940" />
       <Runway Name="32" Position="-313010.860+1503135.390" />
     </Airport>
-    <Airport ICAO="YQLP" FullName="Quilpie" Position="-263631.000+1441526.000">
+    <Airport ICAO="YQLP" FullName="Quilpie" Position="-263631.000+1441526.000" Elevation="655">
       <Runway Name="09" Position="-263631.920+1441500.010" />
       <Runway Name="27" Position="-263635.460+1441554.020" />
       <Runway Name="18" Position="-263605.450+1441521.200" />
       <Runway Name="36" Position="-263639.230+1441511.370" />
     </Airport>
-    <Airport ICAO="YQNS" FullName="Queenstown" Position="-420432.000+1453151.000" />
-    <Airport ICAO="YQRN" FullName="Quorn" Position="-321912.000+1380606.000" />
+    <Airport ICAO="YQNS" FullName="Queenstown" Position="-420432.000+1453151.000" Elevation="867" />
+    <Airport ICAO="YQRN" FullName="Quorn" Position="-321912.000+1380606.000" Elevation="831" />
     <Airport ICAO="YRAC" FullName="Ravensworth Coal Chpp" Position="-322411.000+1510058.000" />
     <Airport ICAO="YRAR" FullName="Moree/Rural Air Work" Position="-291827.000+1494211.000" />
     <Airport ICAO="YRAW" FullName="Rawlinna" Position="-310100.000+1251930.000" />
     <Airport ICAO="YRAY" FullName="Rose Bay" Position="-335212.000+1511547.000" />
     <Airport ICAO="YRBC" FullName="Royal Brisbane Hospital Charlie" Position="-272700.000+1530140.000" />
-    <Airport ICAO="YRBE" FullName="Robe" Position="-371035.000+1394816.000" />
+    <Airport ICAO="YRBE" FullName="Robe" Position="-371035.000+1394816.000" Elevation="6" />
     <Airport ICAO="YRBH" FullName="Royal Brisbane Hospital Alpha" Position="-272649.000+1530142.000" />
-    <Airport ICAO="YRBK" FullName="Robertson Barracks" Position="-122530.000+1305824.000" />
-    <Airport ICAO="YRCD" FullName="Rochedale" Position="-273444.000+1530751.000" />
+    <Airport ICAO="YRBK" FullName="Robertson Barracks" Position="-122530.000+1305824.000" Elevation="105" />
+    <Airport ICAO="YRCD" FullName="Rochedale" Position="-273444.000+1530751.000" Elevation="240" />
     <Airport ICAO="YRDP" FullName="Reindeer Platform" Position="-200130.000+1161836.000" />
-    <Airport ICAO="YRED" FullName="Redcliffe" Position="-271224.000+1530404.000" />
+    <Airport ICAO="YRED" FullName="Redcliffe" Position="-271224.000+1530404.000" Elevation="7" />
     <Airport ICAO="YREM" FullName="Remlap Park" Position="-323323.000+1515725.000" />
-    <Airport ICAO="YREN" FullName="Renmark" Position="-341147.000+1404026.000">
+    <Airport ICAO="YREN" FullName="Renmark" Position="-341147.000+1404026.000" Elevation="115">
       <Runway Name="07" Position="-341201.420+1403934.350" />
       <Runway Name="25" Position="-341145.950+1404039.620" />
       <Runway Name="18" Position="-341146.870+1404043.220" />
       <Runway Name="36" Position="-341219.960+1404039.680" />
     </Airport>
     <Airport ICAO="YRFB" FullName="Raffles Bay" Position="-111622.000+1322307.000" />
-    <Airport ICAO="YRID" FullName="Riddell" Position="-372848.000+1444306.000" />
+    <Airport ICAO="YRID" FullName="Riddell" Position="-372848.000+1444306.000" Elevation="1150" />
     <Airport ICAO="YRKP" FullName="Arkapena" Position="-314018.000+1383809.000" />
-    <Airport ICAO="YRLL" FullName="Rolleston" Position="-242739.000+1483739.000" />
-    <Airport ICAO="YRMD" FullName="Richmond (Qld)" Position="-204207.000+1430653.000">
+    <Airport ICAO="YRLL" FullName="Rolleston" Position="-242739.000+1483739.000" Elevation="730" />
+    <Airport ICAO="YRMD" FullName="Richmond (Qld)" Position="-204207.000+1430653.000" Elevation="677">
       <Runway Name="09" Position="-204200.520+1430623.480" />
       <Runway Name="27" Position="-204207.990+1430715.480" />
     </Airport>
-    <Airport ICAO="YRNG" FullName="Ramingining" Position="-122123.000+1345351.000">
+    <Airport ICAO="YRNG" FullName="Ramingining" Position="-122123.000+1345351.000" Elevation="216">
       <Runway Name="09" Position="-122124.430+1345309.360" />
       <Runway Name="27" Position="-122126.280+1345355.010" />
     </Airport>
-    <Airport ICAO="YROB" FullName="Robinhood" Position="-185055.000+1434240.000" />
+    <Airport ICAO="YROB" FullName="Robinhood" Position="-185055.000+1434240.000" Elevation="1509" />
     <Airport ICAO="YROC" FullName="Ravensworth Open Cut" Position="-322656.000+1510120.000" />
     <Airport ICAO="YROE" FullName="Roebourne" Position="-204541.000+1170922.000" />
-    <Airport ICAO="YROI" FullName="Robinvale" Position="-343902.000+1424658.000">
+    <Airport ICAO="YROI" FullName="Robinvale" Position="-343902.000+1424658.000" Elevation="284">
       <Runway Name="01" Position="-343848.600+1424613.520" />
       <Runway Name="19" Position="-343816.250+1424635.250" />
       <Runway Name="12" Position="-343832.670+1424620.600" />
       <Runway Name="30" Position="-343859.190+1424653.780" />
     </Airport>
     <Airport ICAO="YROL" FullName="Rolleston Open Cut" Position="-242643.000+1482505.000" />
-    <Airport ICAO="YROM" FullName="Roma" Position="-263243.000+1484630.000">
+    <Airport ICAO="YROM" FullName="Roma" Position="-263243.000+1484630.000" Elevation="1027">
       <Runway Name="09" Position="-263238.760+1484558.830" />
       <Runway Name="27" Position="-263243.980+1484627.220" />
       <Runway Name="18" Position="-263215.550+1484637.570" />
       <Runway Name="36" Position="-263303.420+1484626.620" />
     </Airport>
     <Airport ICAO="YROV" FullName="Ross River" Position="-233558.000+1343102.000" />
-    <Airport ICAO="YRPA" FullName="Royal Prince Alfred Hospital" Position="-335322.000+1511102.000" />
+    <Airport ICAO="YRPA" FullName="Royal Prince Alfred Hospital" Position="-335322.000+1511102.000" Elevation="96" />
     <Airport ICAO="YRPT" FullName="Rankin Point" Position="-124100.000+1303500.000" />
-    <Airport ICAO="YRSB" FullName="Roseberth" Position="-255000.000+1393900.000" />
-    <Airport ICAO="YRSH" FullName="Rosehill Heliport" Position="-334949.000+1510127.000" />
+    <Airport ICAO="YRSB" FullName="Roseberth" Position="-255000.000+1393900.000" Elevation="180" />
+    <Airport ICAO="YRSH" FullName="Rosehill Heliport" Position="-334949.000+1510127.000" Elevation="12" />
     <Airport ICAO="YRSS" FullName="Risdon Stud" Position="-281823.000+1515827.000" />
-    <Airport ICAO="YRSY" FullName="Romsey" Position="-372330.000+1444418.000" />
+    <Airport ICAO="YRSY" FullName="Romsey" Position="-372330.000+1444418.000" Elevation="1500" />
     <Airport ICAO="YRTH" FullName="Little River/Rothwell" Position="-375300.000+1442636.000" />
-    <Airport ICAO="YRTI" FullName="Rottnest Island" Position="-320024.000+1153223.000">
+    <Airport ICAO="YRTI" FullName="Rottnest Island" Position="-320024.000+1153223.000" Elevation="12">
       <Runway Name="09" Position="-320022.550+1153158.210" />
       <Runway Name="27" Position="-320022.780+1153240.870" />
     </Airport>
-    <Airport ICAO="YRTP" FullName="Rutland Plains" Position="-153836.000+1415036.000" />
-    <Airport ICAO="YRVL" FullName="Rose Vale" Position="-345058.000+1474649.000" />
+    <Airport ICAO="YRTP" FullName="Rutland Plains" Position="-153836.000+1415036.000" Elevation="50" />
+    <Airport ICAO="YRVL" FullName="Rose Vale" Position="-345058.000+1474649.000" Elevation="800" />
     <Airport ICAO="YRVW" FullName="Ravenswood" Position="-200600.000+1465400.000" />
     <Airport ICAO="YRWF" FullName="Rowland Flat" Position="-343400.000+1385700.000" />
     <Airport ICAO="YRWS" FullName="Rowsley" Position="-374240.000+1442239.000" />
     <Airport ICAO="YRYA" FullName="Ryans Point" Position="-433229.000+1465342.000" />
     <Airport ICAO="YRYK" FullName="Rawnsley Park" Position="-313911.000+1383635.000" />
-    <Airport ICAO="YRYL" FullName="Rylstone Airpark" Position="-324615.000+1495936.000" />
-    <Airport ICAO="YRYP" FullName="Rayner Place Heliport" Position="-345146.000+1485602.000" />
-    <Airport ICAO="YRYW" FullName="Raywood" Position="-363230.000+1441428.000" />
+    <Airport ICAO="YRYL" FullName="Rylstone Airpark" Position="-324615.000+1495936.000" Elevation="1990" />
+    <Airport ICAO="YRYP" FullName="Rayner Place Heliport" Position="-345146.000+1485602.000" Elevation="1660" />
+    <Airport ICAO="YRYW" FullName="Raywood" Position="-363230.000+1441428.000" Elevation="450" />
     <Airport ICAO="YSAF" FullName="Scampton Airfield" Position="-305824.000+1501059.000" />
-    <Airport ICAO="YSAM" FullName="Samarai" Position="-271422.000+1514104.000" />
+    <Airport ICAO="YSAM" FullName="Samarai" Position="-271422.000+1514104.000" Elevation="1400" />
     <Airport ICAO="YSAW" FullName="Sawfish Camp" Position="-150738.000+1350032.000" />
     <Airport ICAO="YSBE" FullName="Sunbury East" Position="-373148.000+1444454.000" />
     <Airport ICAO="YSBH" FullName="Sadies Beach Helipad" Position="-103437.000+1421355.000" />
-    <Airport ICAO="YSBK" FullName="Sydney/Bankstown" Position="-335528.000+1505918.000">
+    <Airport ICAO="YSBK" FullName="Sydney/Bankstown" Position="-335528.000+1505918.000" Elevation="34">
       <Runway Name="11C" Position="-335512.430+1505904.400" />
       <Runway Name="29C" Position="-335535.230+1505945.100" />
       <Runway Name="11L" Position="-335512.440+1505911.930" />
@@ -19147,130 +19163,130 @@ BOFOR
       <Runway Name="29L" Position="-335536.600+1505940.170" />
     </Airport>
     <Airport ICAO="YSBY" FullName="Seabuoy" Position="-202548.000+1164251.000" />
-    <Airport ICAO="YSCA" FullName="Scotianctuary" Position="-331218.000+1411001.000" />
-    <Airport ICAO="YSCB" FullName="Canberra Act" Position="-351825.000+1491142.000">
+    <Airport ICAO="YSCA" FullName="Scotianctuary" Position="-331218.000+1411001.000" Elevation="180" />
+    <Airport ICAO="YSCB" FullName="Canberra Act" Position="-351825.000+1491142.000" Elevation="1886">
       <Runway Name="12" Position="-351802.460+1491106.550" />
       <Runway Name="30" Position="-351835.990+1491155.540" />
       <Runway Name="17" Position="-351726.260+1491139.990" />
       <Runway Name="35" Position="-351853.310+1491140.000" />
     </Airport>
-    <Airport ICAO="YSCD" FullName="Carosue Dam" Position="-301025.000+1221920.000">
+    <Airport ICAO="YSCD" FullName="Carosue Dam" Position="-301025.000+1221920.000" Elevation="1291">
       <Runway Name="06" Position="-301042.200+1221847.640" />
       <Runway Name="24" Position="-301012.040+1221953.870" />
     </Airport>
     <Airport ICAO="YSCF" FullName="Scawfell Island" Position="-204601.000+1495713.000" />
-    <Airport ICAO="YSCN" FullName="Camden" Position="-340225.000+1504112.000">
+    <Airport ICAO="YSCN" FullName="Camden" Position="-340225.000+1504112.000" Elevation="230">
       <Runway Name="06" Position="-340226.230+1504050.230" />
       <Runway Name="24" Position="-340210.270+1504130.980" />
       <Runway Name="10" Position="-340229.410+1504054.250" />
       <Runway Name="28" Position="-340237.800+1504120.570" />
     </Airport>
-    <Airport ICAO="YSCO" FullName="Scone" Position="-320214.000+1504956.000">
+    <Airport ICAO="YSCO" FullName="Scone" Position="-320214.000+1504956.000" Elevation="745">
       <Runway Name="11" Position="-320205.380+1504933.370" />
       <Runway Name="29" Position="-320229.240+1505018.770" />
     </Airport>
     <Airport ICAO="YSCP" FullName="Scoresby/Caribbean Park" Position="-375432.000+1451324.000" />
-    <Airport ICAO="YSCR" FullName="Southern Cross" Position="-311425.000+1192135.000">
+    <Airport ICAO="YSCR" FullName="Southern Cross" Position="-311425.000+1192135.000" Elevation="1163">
       <Runway Name="09" Position="-311426.880+1192109.440" />
       <Runway Name="27" Position="-311426.880+1192159.350" />
       <Runway Name="14" Position="-311357.790+1192104.200" />
       <Runway Name="32" Position="-311431.860+1192139.530" />
     </Airport>
-    <Airport ICAO="YSDU" FullName="Dubbo" Position="-321300.000+1483429.000">
+    <Airport ICAO="YSDU" FullName="Dubbo" Position="-321300.000+1483429.000" Elevation="935">
       <Runway Name="05" Position="-321322.160+1483407.810" />
       <Runway Name="23" Position="-321249.350+1483500.430" />
       <Runway Name="11" Position="-321251.740+1483424.410" />
       <Runway Name="29" Position="-321308.560+1483500.030" />
     </Airport>
-    <Airport ICAO="YSEN" FullName="Serpentine" Position="-322342.000+1155224.000" />
-    <Airport ICAO="YSFG" FullName="Stonefield Gliding" Position="-342030.000+1391830.000" />
-    <Airport ICAO="YSGE" FullName="Saint George" Position="-280259.000+1483543.000">
+    <Airport ICAO="YSEN" FullName="Serpentine" Position="-322342.000+1155224.000" Elevation="30" />
+    <Airport ICAO="YSFG" FullName="Stonefield Gliding" Position="-342030.000+1391830.000" Elevation="350" />
+    <Airport ICAO="YSGE" FullName="Saint George" Position="-280259.000+1483543.000" Elevation="656">
       <Runway Name="11" Position="-280248.810+1483519.900" />
       <Runway Name="29" Position="-280313.980+1483607.920" />
     </Airport>
-    <Airport ICAO="YSGR" FullName="South Grafton" Position="-294232.000+1525542.000" />
-    <Airport ICAO="YSGT" FullName="Singleton" Position="-323700.000+1511200.000" />
-    <Airport ICAO="YSGW" FullName="South Galway" Position="-254029.000+1420524.000" />
-    <Airport ICAO="YSHK" FullName="Shark Bay" Position="-255338.000+1133438.000">
+    <Airport ICAO="YSGR" FullName="South Grafton" Position="-294232.000+1525542.000" Elevation="20" />
+    <Airport ICAO="YSGT" FullName="Singleton" Position="-323700.000+1511200.000" Elevation="150" />
+    <Airport ICAO="YSGW" FullName="South Galway" Position="-254029.000+1420524.000" Elevation="380" />
+    <Airport ICAO="YSHK" FullName="Shark Bay" Position="-255338.000+1133438.000" Elevation="129">
       <Runway Name="18" Position="-255319.920+1133432.030" />
       <Runway Name="36" Position="-255414.780+1133434.000" />
     </Airport>
-    <Airport ICAO="YSHL" FullName="Shellharbour Airport" Position="-343340.000+1504719.000">
+    <Airport ICAO="YSHL" FullName="Shellharbour Airport" Position="-343340.000+1504719.000" Elevation="31">
       <Runway Name="08" Position="-343344.210+1504654.460" />
       <Runway Name="26" Position="-343347.180+1504743.040" />
       <Runway Name="16" Position="-343305.430+1504707.300" />
       <Runway Name="34" Position="-343357.880+1504719.290" />
     </Airport>
-    <Airport ICAO="YSHR" FullName="Shute Harbour/Whitsunday" Position="-201642.000+1484520.000" />
-    <Airport ICAO="YSHT" FullName="Shepparton" Position="-362544.000+1452333.000">
+    <Airport ICAO="YSHR" FullName="Shute Harbour/Whitsunday" Position="-201642.000+1484520.000" Elevation="40" />
+    <Airport ICAO="YSHT" FullName="Shepparton" Position="-362544.000+1452333.000" Elevation="375">
       <Runway Name="09" Position="-362546.120+1452327.040" />
       <Runway Name="27" Position="-362548.430+1452344.240" />
       <Runway Name="36" Position="-362556.230+1452326.260" />
       <Runway Name="18" Position="-362519.650+1452334.680" />
     </Airport>
-    <Airport ICAO="YSHW" FullName="Holsworthy" Position="-335942.000+1505709.000">
+    <Airport ICAO="YSHW" FullName="Holsworthy" Position="-335942.000+1505709.000" Elevation="250">
       <Runway Name="11" Position="-335938.250+1505656.600" />
       <Runway Name="29" Position="-335950.260+1505718.380" />
     </Airport>
-    <Airport ICAO="YSII" FullName="Saibai Island" Position="-092242.000+1423730.000">
+    <Airport ICAO="YSII" FullName="Saibai Island" Position="-092242.000+1423730.000" Elevation="15">
       <Runway Name="12" Position="-092234.740+1423721.360" />
       <Runway Name="30" Position="-092250.400+1423739.120" />
     </Airport>
     <Airport ICAO="YSKF" FullName="Starke Field" Position="-193512.000+1464650.000" />
     <Airport ICAO="YSKR" FullName="Skardon River" Position="-115208.000+1420058.000" />
-    <Airport ICAO="YSLK" FullName="Sea Lake" Position="-353154.000+1425326.000" />
+    <Airport ICAO="YSLK" FullName="Sea Lake" Position="-353154.000+1425326.000" Elevation="184" />
     <Airport ICAO="YSLN" FullName="Strathleven" Position="-155354.000+1432300.000" />
-    <Airport ICAO="YSMB" FullName="Somersby" Position="-332204.000+1511759.000" />
+    <Airport ICAO="YSMB" FullName="Somersby" Position="-332204.000+1511759.000" Elevation="830" />
     <Airport ICAO="YSMH" FullName="Samuel Hill" Position="-224500.000+1503800.000" />
-    <Airport ICAO="YSMI" FullName="Smithton" Position="-405006.000+1450501.000" />
+    <Airport ICAO="YSMI" FullName="Smithton" Position="-405006.000+1450501.000" Elevation="31" />
     <Airport ICAO="YSNC" FullName="Sinclair" Position="-282020.000+1205110.000" />
-    <Airport ICAO="YSNF" FullName="Norfolk Island" Position="-290233.000+1675617.000">
+    <Airport ICAO="YSNF" FullName="Norfolk Island" Position="-290233.000+1675617.000" Elevation="371">
       <Runway Name="04" Position="-290247.660+1675559.500" />
       <Runway Name="22" Position="-290217.610+1675640.190" />
       <Runway Name="11" Position="-290211.680+1675547.990" />
       <Runway Name="29" Position="-290244.460+1675647.110" />
     </Airport>
-    <Airport ICAO="YSNK" FullName="Snake Bay" Position="-112522.000+1303913.000">
+    <Airport ICAO="YSNK" FullName="Snake Bay" Position="-112522.000+1303913.000" Elevation="173">
       <Runway Name="13" Position="-112449.300+1303836.950" />
       <Runway Name="31" Position="-112519.140+1303913.700" />
     </Airport>
-    <Airport ICAO="YSNW" FullName="Nowra" Position="-345656.000+1503213.000">
+    <Airport ICAO="YSNW" FullName="Nowra" Position="-345656.000+1503213.000" Elevation="400">
       <Runway Name="03" Position="-345655.820+1503211.270" />
       <Runway Name="21" Position="-345608.370+1503307.670" />
       <Runway Name="08" Position="-345652.370+1503135.730" />
       <Runway Name="26" Position="-345657.560+1503258.030" />
     </Airport>
-    <Airport ICAO="YSNY" FullName="Sunnyside" Position="-354547.000+1465433.000" />
-    <Airport ICAO="YSOL" FullName="Solomon" Position="-221517.000+1175058.000">
+    <Airport ICAO="YSNY" FullName="Sunnyside" Position="-354547.000+1465433.000" Elevation="705" />
+    <Airport ICAO="YSOL" FullName="Solomon" Position="-221517.000+1175058.000" Elevation="2008">
       <Runway Name="09" Position="-221524.470+1175026.710" />
       <Runway Name="27" Position="-221524.060+1175136.620" />
     </Airport>
-    <Airport ICAO="YSPE" FullName="Stanthorpe" Position="-283713.000+1515926.000">
+    <Airport ICAO="YSPE" FullName="Stanthorpe" Position="-283713.000+1515926.000" Elevation="2934">
       <Runway Name="08" Position="-283711.770+1515820.960" />
       <Runway Name="26" Position="-283712.920+1515923.850" />
     </Airport>
-    <Airport ICAO="YSPI" FullName="Springsure" Position="-240754.000+1480506.000" />
-    <Airport ICAO="YSPK" FullName="Spring Creek" Position="-183718.000+1443406.000" />
-    <Airport ICAO="YSPT" FullName="Southport" Position="-275518.000+1532217.000">
+    <Airport ICAO="YSPI" FullName="Springsure" Position="-240754.000+1480506.000" Elevation="1200" />
+    <Airport ICAO="YSPK" FullName="Spring Creek" Position="-183718.000+1443406.000" Elevation="1700" />
+    <Airport ICAO="YSPT" FullName="Southport" Position="-275518.000+1532217.000" Elevation="5">
       <Runway Name="01" Position="-275525.000+1532214.000" />
       <Runway Name="19" Position="-275512.000+1532221.000" />
     </Airport>
     <Airport ICAO="YSPY" FullName="Spilsby Island" Position="-343930.000+1362024.000" />
-    <Airport ICAO="YSRD" FullName="Sunrise Dam" Position="-290554.000+1222719.000">
+    <Airport ICAO="YSRD" FullName="Sunrise Dam" Position="-290554.000+1222719.000" Elevation="1350">
       <Runway Name="06" Position="-290612.120+1222651.240" />
       <Runway Name="24" Position="-290540.730+1222753.880" />
     </Airport>
-    <Airport ICAO="YSRG" FullName="Sunraysia Gliding" Position="-341535.000+1420330.000" />
-    <Airport ICAO="YSRI" FullName="Richmond (NSW)" Position="-333602.000+1504651.000">
+    <Airport ICAO="YSRG" FullName="Sunraysia Gliding" Position="-341535.000+1420330.000" Elevation="165" />
+    <Airport ICAO="YSRI" FullName="Richmond (NSW)" Position="-333602.000+1504651.000" Elevation="67">
       <Runway Name="10" Position="-333605.810+1504616.490" />
       <Runway Name="28" Position="-333626.180+1504735.590" />
     </Airport>
-    <Airport ICAO="YSRN" FullName="Strahan" Position="-420920.000+1451729.000">
+    <Airport ICAO="YSRN" FullName="Strahan" Position="-420920.000+1451729.000" Elevation="66">
       <Runway Name="18" Position="-420901.400+1451728.990" />
       <Runway Name="36" Position="-420940.140+1451718.520" />
     </Airport>
-    <Airport ICAO="YSRT" FullName="Surat" Position="-270934.000+1490434.000" />
-    <Airport ICAO="YSSY" FullName="Sydney/Kingsford Smith" Position="-335646.000+1511038.000">
+    <Airport ICAO="YSRT" FullName="Surat" Position="-270934.000+1490434.000" Elevation="837" />
+    <Airport ICAO="YSSY" FullName="Sydney/Kingsford Smith" Position="-335646.000+1511038.000" Elevation="21">
       <Runway Name="07" Position="-335637.460+1510949.060" />
       <Runway Name="25" Position="-335615.990+1511120.070" />
       <Runway Name="16L" Position="-335705.890+1511119.850" />
@@ -19278,7 +19294,7 @@ BOFOR
       <Runway Name="16R" Position="-335548.350+1511018.430" />
       <Runway Name="34L" Position="-335751.350+1511050.330" />
     </Airport>
-    <Airport ICAO="YSTA" FullName="St Arnaud" Position="-363812.000+1431109.000">
+    <Airport ICAO="YSTA" FullName="St Arnaud" Position="-363812.000+1431109.000" Elevation="640">
       <Runway Name="09" Position="-363839.720+1431038.160" />
       <Runway Name="27" Position="-363841.910+1431059.510" />
       <Runway Name="18" Position="-363815.900+1431105.950" />
@@ -19286,15 +19302,15 @@ BOFOR
     </Airport>
     <Airport ICAO="YSTD" FullName="Star Landing Area" Position="-192030.000+1461000.000" />
     <Airport ICAO="YSTG" FullName="Stag Platform" Position="-201725.000+1161631.000" />
-    <Airport ICAO="YSTH" FullName="Saint Helens" Position="-412012.000+1481655.000">
+    <Airport ICAO="YSTH" FullName="Saint Helens" Position="-412012.000+1481655.000" Elevation="158">
       <Runway Name="08" Position="-412014.940+1481644.880" />
       <Runway Name="26" Position="-412017.100+1481730.890" />
     </Airport>
-    <Airport ICAO="YSTL" FullName="Stirling Station" Position="-171111.000+1414242.000" />
+    <Airport ICAO="YSTL" FullName="Stirling Station" Position="-171111.000+1414242.000" Elevation="150" />
     <Airport ICAO="YSTN" FullName="Stanley" Position="-404840.000+1451532.000" />
-    <Airport ICAO="YSTO" FullName="Stonehenge" Position="-242123.000+1431729.000" />
+    <Airport ICAO="YSTO" FullName="Stonehenge" Position="-242123.000+1431729.000" Elevation="543" />
     <Airport ICAO="YSTR" FullName="Strathearn" Position="-314500.000+1402000.000" />
-    <Airport ICAO="YSTW" FullName="Tamworth" Position="-310502.000+1505048.000">
+    <Airport ICAO="YSTW" FullName="Tamworth" Position="-310502.000+1505048.000" Elevation="1335">
       <Runway Name="06" Position="-310459.410+1505034.460" />
       <Runway Name="24" Position="-310451.450+1505104.840" />
       <Runway Name="12L" Position="-310415.780+1505013.110" />
@@ -19306,55 +19322,55 @@ BOFOR
     </Airport>
     <Airport ICAO="YSUM" FullName="Summerhill Road Helipad" Position="-351604.000+1385512.000" />
     <Airport ICAO="YSVN" FullName="Strathaven" Position="-145400.000+1425800.000" />
-    <Airport ICAO="YSWB" FullName="Swan Bay" Position="-290257.000+1531804.000" />
-    <Airport ICAO="YSWG" FullName="Waggagga" Position="-350955.000+1472759.000">
+    <Airport ICAO="YSWB" FullName="Swan Bay" Position="-290257.000+1531804.000" Elevation="15" />
+    <Airport ICAO="YSWG" FullName="Waggagga" Position="-350955.000+1472759.000" Elevation="724">
       <Runway Name="05" Position="-351001.420+1472736.490" />
       <Runway Name="23" Position="-350934.560+1472838.330" />
       <Runway Name="12" Position="-350951.220+1472747.030" />
       <Runway Name="30" Position="-351007.140+1472814.520" />
     </Airport>
-    <Airport ICAO="YSWH" FullName="Swan Hill" Position="-352233.000+1433158.000">
+    <Airport ICAO="YSWH" FullName="Swan Hill" Position="-352233.000+1433158.000" Elevation="234">
       <Runway Name="04" Position="-352255.170+1433151.770" />
       <Runway Name="22" Position="-352234.640+1433220.610" />
       <Runway Name="08" Position="-352229.640+1433129.540" />
       <Runway Name="26" Position="-352230.440+1433228.710" />
     </Airport>
-    <Airport ICAO="YSWL" FullName="Stawell" Position="-370418.000+1424425.000">
+    <Airport ICAO="YSWL" FullName="Stawell" Position="-370418.000+1424425.000" Elevation="807">
       <Runway Name="11" Position="-370356.210+1424336.860" />
       <Runway Name="29" Position="-370415.270+1424428.490" />
       <Runway Name="18" Position="-370416.710+1424429.490" />
       <Runway Name="36" Position="-370444.330+1424426.180" />
     </Airport>
-    <Airport ICAO="YTAA" FullName="Tara" Position="-270924.000+1502836.000" />
+    <Airport ICAO="YTAA" FullName="Tara" Position="-270924.000+1502836.000" Elevation="1180" />
     <Airport ICAO="YTAH" FullName="Tahmoor Mine" Position="-341508.000+1503436.000" />
-    <Airport ICAO="YTAM" FullName="Taroom" Position="-254807.000+1495358.000">
+    <Airport ICAO="YTAM" FullName="Taroom" Position="-254807.000+1495358.000" Elevation="786">
       <Runway Name="08" Position="-254816.270+1495345.640" />
       <Runway Name="26" Position="-254814.510+1495424.630" />
       <Runway Name="12" Position="-254755.780+1495339.300" />
       <Runway Name="30" Position="-254818.620+1495409.620" />
     </Airport>
-    <Airport ICAO="YTBB" FullName="Tumby Bay" Position="-342140.000+1360542.000">
+    <Airport ICAO="YTBB" FullName="Tumby Bay" Position="-342140.000+1360542.000" Elevation="32">
       <Runway Name="15" Position="-342124.850+1360537.420" />
       <Runway Name="33" Position="-342158.400+1360551.770" />
     </Airport>
     <Airport ICAO="YTBH" FullName="Toobeah/Brendle Downs Station" Position="-283038.000+1495640.000" />
-    <Airport ICAO="YTBR" FullName="Timber Creek" Position="-153714.000+1302644.000" />
+    <Airport ICAO="YTBR" FullName="Timber Creek" Position="-153714.000+1302644.000" Elevation="51" />
     <Airport ICAO="YTCU" FullName="Tucson" Position="-224100.000+1432042.000" />
     <Airport ICAO="YTDM" FullName="Todmorden" Position="-270746.000+1344620.000" />
-    <Airport ICAO="YTDN" FullName="Tooradin" Position="-381256.000+1452525.000" />
-    <Airport ICAO="YTDR" FullName="Theodore" Position="-245911.000+1500535.000">
+    <Airport ICAO="YTDN" FullName="Tooradin" Position="-381256.000+1452525.000" Elevation="10" />
+    <Airport ICAO="YTDR" FullName="Theodore" Position="-245911.000+1500535.000" Elevation="560">
       <Runway Name="17" Position="-245850.240+1500535.170" />
       <Runway Name="35" Position="-245934.100+1500535.120" />
     </Airport>
-    <Airport ICAO="YTEE" FullName="Trepell" Position="-215006.000+1405317.000">
+    <Airport ICAO="YTEE" FullName="Trepell" Position="-215006.000+1405317.000" Elevation="891">
       <Runway Name="14" Position="-214942.990+1405256.730" />
       <Runway Name="32" Position="-215030.290+1405333.590" />
     </Airport>
-    <Airport ICAO="YTEF" FullName="Telfer" Position="-214254.000+1221342.000">
+    <Airport ICAO="YTEF" FullName="Telfer" Position="-214254.000+1221342.000" Elevation="975">
       <Runway Name="12" Position="-214237.610+1221319.110" />
       <Runway Name="30" Position="-214311.580+1221418.440" />
     </Airport>
-    <Airport ICAO="YTEM" FullName="Temora" Position="-342517.000+1473042.000">
+    <Airport ICAO="YTEM" FullName="Temora" Position="-342517.000+1473042.000" Elevation="921">
       <Runway Name="05" Position="-342533.130+1472942.840" />
       <Runway Name="23" Position="-342502.840+1473051.260" />
       <Runway Name="09" Position="-342518.350+1473027.440" />
@@ -19363,29 +19379,29 @@ BOFOR
       <Runway Name="36" Position="-342549.380+1473045.490" />
     </Airport>
     <Airport ICAO="YTES" FullName="Tessa Shoals" Position="-203323.000+1171437.000" />
-    <Airport ICAO="YTFA" FullName="Truro Flat Airpark" Position="-342343.000+1392300.000" />
+    <Airport ICAO="YTFA" FullName="Truro Flat Airpark" Position="-342343.000+1392300.000" Elevation="220" />
     <Airport ICAO="YTGL" FullName="Tregalana" Position="-324912.000+1373317.000">
       <Runway Name="17" Position="-324852.000+1373314.000" />
       <Runway Name="35" Position="-324937.000+1373313.200" />
     </Airport>
-    <Airport ICAO="YTGM" FullName="Thargomindah" Position="-275911.000+1434839.000">
+    <Airport ICAO="YTGM" FullName="Thargomindah" Position="-275911.000+1434839.000" Elevation="433">
       <Runway Name="04" Position="-275941.760+1434829.130" />
       <Runway Name="22" Position="-275924.570+1434853.290" />
       <Runway Name="13" Position="-275853.080+1434827.070" />
       <Runway Name="31" Position="-275929.840+1434901.030" />
     </Airport>
-    <Airport ICAO="YTGT" FullName="The Granites" Position="-203254.000+1302100.000">
+    <Airport ICAO="YTGT" FullName="The Granites" Position="-203254.000+1302100.000" Elevation="1296">
       <Runway Name="11" Position="-203238.520+1302025.640" />
       <Runway Name="29" Position="-203312.540+1302137.900" />
     </Airport>
     <Airport ICAO="YTHB" FullName="Thredbo" Position="-363020.000+1481810.000" />
     <Airport ICAO="YTHD" FullName="Theda Stn" Position="-144717.000+1262947.000" />
-    <Airport ICAO="YTHN" FullName="Thunderbox" Position="-280914.000+1205621.000">
+    <Airport ICAO="YTHN" FullName="Thunderbox" Position="-280914.000+1205621.000" Elevation="1706">
       <Runway Name="07" Position="-280920.490+1205544.990" />
       <Runway Name="25" Position="-280904.190+1205655.940" />
     </Airport>
-    <Airport ICAO="YTHY" FullName="Thylungra" Position="-260536.000+1432709.000" />
-    <Airport ICAO="YTIB" FullName="Tibooburra" Position="-292704.000+1420328.000">
+    <Airport ICAO="YTHY" FullName="Thylungra" Position="-260536.000+1432709.000" Elevation="540" />
+    <Airport ICAO="YTIB" FullName="Tibooburra" Position="-292704.000+1420328.000" Elevation="584">
       <Runway Name="02" Position="-292726.840+1420314.920" />
       <Runway Name="20" Position="-292658.820+1420333.340" />
       <Runway Name="15" Position="-292638.460+1420313.900" />
@@ -19393,47 +19409,47 @@ BOFOR
     </Airport>
     <Airport ICAO="YTIE" FullName="Oak Creek Coal Tieri Township" Position="-230214.000+1482055.000" />
     <Airport ICAO="YTKL" FullName="Turkey Lane" Position="-354415.000+1370756.000" />
-    <Airport ICAO="YTKS" FullName="Toorak Research Station" Position="-210230.000+1414712.000" />
+    <Airport ICAO="YTKS" FullName="Toorak Research Station" Position="-210230.000+1414712.000" Elevation="420" />
     <Airport ICAO="YTLH" FullName="Toogoolawah" Position="-270416.000+1522259.000" />
-    <Airport ICAO="YTLP" FullName="Tilpa" Position="-305532.000+1442512.000" />
-    <Airport ICAO="YTMB" FullName="Tambo" Position="-245020.000+1461735.000" />
-    <Airport ICAO="YTMN" FullName="Tanami" Position="-195800.000+1294332.000" />
-    <Airport ICAO="YTMO" FullName="The Monument" Position="-214843.000+1395524.000">
+    <Airport ICAO="YTLP" FullName="Tilpa" Position="-305532.000+1442512.000" Elevation="280" />
+    <Airport ICAO="YTMB" FullName="Tambo" Position="-245020.000+1461735.000" Elevation="1500" />
+    <Airport ICAO="YTMN" FullName="Tanami" Position="-195800.000+1294332.000" Elevation="1400" />
+    <Airport ICAO="YTMO" FullName="The Monument" Position="-214843.000+1395524.000" Elevation="949">
       <Runway Name="14" Position="-214807.570+1395459.140" />
       <Runway Name="32" Position="-214858.680+1395536.290" />
     </Airport>
-    <Airport ICAO="YTMU" FullName="Tumut" Position="-351546.000+1481427.000">
+    <Airport ICAO="YTMU" FullName="Tumut" Position="-351546.000+1481427.000" Elevation="863">
       <Runway Name="17" Position="-351548.390+1481426.520" />
       <Runway Name="35" Position="-351622.760+1481425.090" />
     </Airport>
-    <Airport ICAO="YTNG" FullName="Thangool" Position="-242938.000+1503434.000">
+    <Airport ICAO="YTNG" FullName="Thangool" Position="-242938.000+1503434.000" Elevation="644">
       <Runway Name="10" Position="-242933.600+1503418.720" />
       <Runway Name="28" Position="-242951.770+1503509.190" />
       <Runway Name="14" Position="-242931.620+1503431.570" />
       <Runway Name="32" Position="-242951.330+1503449.850" />
     </Airport>
-    <Airport ICAO="YTNK" FullName="Tennant Creek" Position="-193804.000+1341100.000">
+    <Airport ICAO="YTNK" FullName="Tennant Creek" Position="-193804.000+1341100.000" Elevation="1236">
       <Runway Name="07" Position="-193809.160+1341010.820" />
       <Runway Name="25" Position="-193751.990+1341115.590" />
       <Runway Name="11" Position="-193801.700+1341033.320" />
       <Runway Name="29" Position="-193818.500+1341104.980" />
     </Airport>
-    <Airport ICAO="YTOC" FullName="Tocumwal" Position="-354839.000+1453615.000">
+    <Airport ICAO="YTOC" FullName="Tocumwal" Position="-354839.000+1453615.000" Elevation="372">
       <Runway Name="09" Position="-354836.280+1453542.060" />
       <Runway Name="27" Position="-354842.110+1453629.460" />
       <Runway Name="18" Position="-354814.740+1453621.340" />
       <Runway Name="36" Position="-354855.590+1453613.830" />
     </Airport>
     <Airport ICAO="YTOO" FullName="Maryland Too" Position="-332212.000+1205254.000" />
-    <Airport ICAO="YTOT" FullName="Tottenham" Position="-321522.000+1472208.000" />
-    <Airport ICAO="YTPK" FullName="Turtle Park" Position="-211230.000+1485842.000" />
+    <Airport ICAO="YTOT" FullName="Tottenham" Position="-321522.000+1472208.000" Elevation="780" />
+    <Airport ICAO="YTPK" FullName="Turtle Park" Position="-211230.000+1485842.000" Elevation="120" />
     <Airport ICAO="YTPL" FullName="Toopuntul" Position="-342103.000+1440400.000" />
-    <Airport ICAO="YTQY" FullName="Torquay" Position="-381800.000+1442154.000" />
-    <Airport ICAO="YTRA" FullName="Tropicana" Position="-291112.000+1243301.000">
+    <Airport ICAO="YTQY" FullName="Torquay" Position="-381800.000+1442154.000" Elevation="30" />
+    <Airport ICAO="YTRA" FullName="Tropicana" Position="-291112.000+1243301.000" Elevation="1104">
       <Runway Name="09" Position="-291110.200+1243222.800" />
       <Runway Name="27" Position="-291109.000+1243340.200" />
     </Airport>
-    <Airport ICAO="YTRE" FullName="Taree" Position="-315319.000+1523050.000">
+    <Airport ICAO="YTRE" FullName="Taree" Position="-315319.000+1523050.000" Elevation="38">
       <Runway Name="04" Position="-315334.250+1523035.720" />
       <Runway Name="22" Position="-315259.700+1523116.270" />
       <Runway Name="12" Position="-315304.140+1523029.880" />
@@ -19441,32 +19457,32 @@ BOFOR
     </Airport>
     <Airport ICAO="YTRG" FullName="Traeger" Position="-301234.000+1351352.000" />
     <Airport ICAO="YTRS" FullName="Three Rocks" Position="-205601.000+1494507.000" />
-    <Airport ICAO="YTST" FullName="Truscott-Mungalalu" Position="-140523.000+1262251.000">
+    <Airport ICAO="YTST" FullName="Truscott-Mungalalu" Position="-140523.000+1262251.000" Elevation="181">
       <Runway Name="12" Position="-140457.220+1262224.890" />
       <Runway Name="30" Position="-140533.540+1262311.930" />
     </Airport>
-    <Airport ICAO="YTTI" FullName="Troughton Island" Position="-134506.000+1260854.000">
+    <Airport ICAO="YTTI" FullName="Troughton Island" Position="-134506.000+1260854.000" Elevation="27">
       <Runway Name="14" Position="-134454.310+1260847.480" />
       <Runway Name="32" Position="-134521.300+1260905.040" />
     </Airport>
     <Airport ICAO="YTUB" FullName="Wakool/Tullaburra" Position="-352729.000+1441656.000" />
     <Airport ICAO="YTUM" FullName="Tumbar Station" Position="-235905.000+1461636.000" />
-    <Airport ICAO="YTUY" FullName="Tully" Position="-175610.000+1455616.000" />
+    <Airport ICAO="YTUY" FullName="Tully" Position="-175610.000+1455616.000" Elevation="47" />
     <Airport ICAO="YTWA" FullName="Tierawoomba" Position="-215120.000+1490205.000" />
-    <Airport ICAO="YTWB" FullName="Toowoomba" Position="-273229.000+1515445.000">
+    <Airport ICAO="YTWB" FullName="Toowoomba" Position="-273229.000+1515445.000" Elevation="2087">
       <Runway Name="06" Position="-273238.340+1515440.250" />
       <Runway Name="24" Position="-273231.850+1515503.180" />
       <Runway Name="11" Position="-273225.500+1515445.350" />
       <Runway Name="29" Position="-273243.390+1515525.060" />
     </Airport>
-    <Airport ICAO="YTWG" FullName="Towrang Gliding" Position="-344127.000+1495317.000" />
-    <Airport ICAO="YTWN" FullName="Tooraweenah" Position="-312630.000+1485400.000" />
-    <Airport ICAO="YTYA" FullName="Tyabb" Position="-381600.000+1451030.000" />
-    <Airport ICAO="YTYH" FullName="Tyagarah" Position="-283541.000+1533304.000" />
+    <Airport ICAO="YTWG" FullName="Towrang Gliding" Position="-344127.000+1495317.000" Elevation="2045" />
+    <Airport ICAO="YTWN" FullName="Tooraweenah" Position="-312630.000+1485400.000" Elevation="1380" />
+    <Airport ICAO="YTYA" FullName="Tyabb" Position="-381600.000+1451030.000" Elevation="88" />
+    <Airport ICAO="YTYH" FullName="Tyagarah" Position="-283541.000+1533304.000" Elevation="10" />
     <Airport ICAO="YUAL" FullName="Halibut Platform" Position="-382416.000+1481913.000" />
     <Airport ICAO="YUBX" FullName="Cobia Platform" Position="-382659.000+1481833.000" />
-    <Airport ICAO="YUDA" FullName="Undara" Position="-181130.000+1443648.000" />
-    <Airport ICAO="YUDG" FullName="Urandangi" Position="-213540.000+1382156.000" />
+    <Airport ICAO="YUDA" FullName="Undara" Position="-181130.000+1443648.000" Elevation="2450" />
+    <Airport ICAO="YUDG" FullName="Urandangi" Position="-213540.000+1382156.000" Elevation="584" />
     <Airport ICAO="YUFA" FullName="Kingfish A Platform" Position="-383548.000+1480841.000" />
     <Airport ICAO="YUFB" FullName="Kingfish B Platform" Position="-383550.000+1481117.000" />
     <Airport ICAO="YUFW" FullName="West Kingfish Platform" Position="-383536.000+1480620.000" />
@@ -19477,8 +19493,8 @@ BOFOR
     <Airport ICAO="YUMU" FullName="Umuwa" Position="-262912.000+1320224.000" />
     <Airport ICAO="YUNA" FullName="Tuna Platform" Position="-381012.000+1482510.000" />
     <Airport ICAO="YUNW" FullName="West Tuna Platform" Position="-381133.000+1482319.000" />
-    <Airport ICAO="YUNY" FullName="Cluny" Position="-243041.000+1393702.000" />
-    <Airport ICAO="YUOF" FullName="Longford Heliport" Position="-381311.000+1471008.000" />
+    <Airport ICAO="YUNY" FullName="Cluny" Position="-243041.000+1393702.000" Elevation="295" />
+    <Airport ICAO="YUOF" FullName="Longford Heliport" Position="-381311.000+1471008.000" Elevation="171" />
     <Airport ICAO="YUPA" FullName="Dolphin Platform" Position="-382914.000+1472239.000" />
     <Airport ICAO="YUPE" FullName="Perch Platform" Position="-383409.000+1471921.000" />
     <Airport ICAO="YUPG" FullName="Urapunga" Position="-144219.000+1343344.000" />
@@ -19490,128 +19506,128 @@ BOFOR
     <Airport ICAO="YUTA" FullName="Barracouta Platform" Position="-381748.000+1474034.000" />
     <Airport ICAO="YUWH" FullName="Whiting Platform" Position="-381424.000+1475226.000" />
     <Airport ICAO="YVAF" FullName="Truro/Valley Farm" Position="-342314.000+1390839.000" />
-    <Airport ICAO="YVAL" FullName="The Vale" Position="-412548.000+1461548.000" />
+    <Airport ICAO="YVAL" FullName="The Vale" Position="-412548.000+1461548.000" Elevation="723" />
     <Airport ICAO="YVAN" FullName="Vansittart Bay" Position="-135944.000+1260828.000" />
     <Airport ICAO="YVIE" FullName="Victor Island East" Position="-211517.000+1492512.000" />
     <Airport ICAO="YVIL" FullName="The Ville" Position="-191500.000+1464934.000" />
     <Airport ICAO="YVIW" FullName="Victor Island West" Position="-211746.000+1492134.000" />
     <Airport ICAO="YVNS" FullName="Vaughan Springs" Position="-222000.000+1305200.000" />
     <Airport ICAO="YVPC" FullName="Victoria Police Centre" Position="-374852.000+1445704.000" />
-    <Airport ICAO="YVRD" FullName="Victoria River Downs" Position="-162413.000+1310009.000" />
-    <Airport ICAO="YVRS" FullName="Van Rook Station" Position="-165744.000+1415709.000" />
+    <Airport ICAO="YVRD" FullName="Victoria River Downs" Position="-162413.000+1310009.000" Elevation="291" />
+    <Airport ICAO="YVRS" FullName="Van Rook Station" Position="-165744.000+1415709.000" Elevation="140" />
     <Airport ICAO="YVTH" FullName="Victor Harbor" Position="-353343.000+1383623.000" />
     <Airport ICAO="YWAA" FullName="Wandoo Alpha" Position="-200812.000+1162510.000" />
     <Airport ICAO="YWAF" FullName="Wakefield" Position="-305541.000+1504807.000" />
-    <Airport ICAO="YWAG" FullName="Wanaaring" Position="-294242.000+1441016.000" />
+    <Airport ICAO="YWAG" FullName="Wanaaring" Position="-294242.000+1441016.000" Elevation="360" />
     <Airport ICAO="YWAN" FullName="Wanda Beach" Position="-340223.000+1510949.000" />
     <Airport ICAO="YWAO" FullName="Wandoo Bravo" Position="-200726.000+1162602.000" />
-    <Airport ICAO="YWAV" FullName="Wave Hill" Position="-172337.000+1310709.000" />
-    <Airport ICAO="YWBI" FullName="Warrabri" Position="-205957.000+1342347.000" />
-    <Airport ICAO="YWBL" FullName="Warrnambool" Position="-381743.000+1422648.000">
+    <Airport ICAO="YWAV" FullName="Wave Hill" Position="-172337.000+1310709.000" Elevation="658" />
+    <Airport ICAO="YWBI" FullName="Warrabri" Position="-205957.000+1342347.000" Elevation="1258" />
+    <Airport ICAO="YWBL" FullName="Warrnambool" Position="-381743.000+1422648.000" Elevation="242">
       <Runway Name="04" Position="-381755.400+1422637.100" />
       <Runway Name="22" Position="-381732.150+1422709.740" />
       <Runway Name="13" Position="-381723.360+1422628.850" />
       <Runway Name="31" Position="-381756.440+1422706.610" />
     </Airport>
-    <Airport ICAO="YWBN" FullName="Wedderburn" Position="-341048.000+1504832.000" />
-    <Airport ICAO="YWBR" FullName="Warburton" Position="-260742.000+1263500.000">
+    <Airport ICAO="YWBN" FullName="Wedderburn" Position="-341048.000+1504832.000" Elevation="850" />
+    <Airport ICAO="YWBR" FullName="Warburton" Position="-260742.000+1263500.000" Elevation="1510">
       <Runway Name="18" Position="-260706.240+1263501.330" />
       <Runway Name="36" Position="-260757.770+1263457.260" />
     </Airport>
-    <Airport ICAO="YWBS" FullName="Warraber Island" Position="-101224.000+1424924.000" />
-    <Airport ICAO="YWCA" FullName="Wilcannia" Position="-313110.000+1432252.000">
+    <Airport ICAO="YWBS" FullName="Warraber Island" Position="-101224.000+1424924.000" Elevation="10" />
+    <Airport ICAO="YWCA" FullName="Wilcannia" Position="-313110.000+1432252.000" Elevation="313">
       <Runway Name="03" Position="-313132.890+1432230.720" />
       <Runway Name="21" Position="-313108.480+1432251.580" />
       <Runway Name="09" Position="-313058.900+1432233.770" />
       <Runway Name="27" Position="-313103.060+1432315.080" />
     </Airport>
-    <Airport ICAO="YWCH" FullName="Walcha" Position="-310026.000+1513319.000" />
-    <Airport ICAO="YWCK" FullName="Warwick" Position="-280858.000+1515635.000">
+    <Airport ICAO="YWCH" FullName="Walcha" Position="-310026.000+1513319.000" Elevation="3744" />
+    <Airport ICAO="YWCK" FullName="Warwick" Position="-280858.000+1515635.000" Elevation="1527">
       <Runway Name="09" Position="-280854.130+1515605.650" />
       <Runway Name="27" Position="-280902.440+1515705.230" />
     </Airport>
-    <Airport ICAO="YWDG" FullName="Windarling" Position="-300155.000+1192314.000" />
-    <Airport ICAO="YWDH" FullName="Windorah" Position="-252447.000+1424002.000">
+    <Airport ICAO="YWDG" FullName="Windarling" Position="-300155.000+1192314.000" Elevation="1502" />
+    <Airport ICAO="YWDH" FullName="Windorah" Position="-252447.000+1424002.000" Elevation="452">
       <Runway Name="04" Position="-252452.030+1423948.490" />
       <Runway Name="22" Position="-252423.480+1424026.300" />
     </Airport>
-    <Airport ICAO="YWDL" FullName="Wondoola" Position="-183430.000+1405330.000" />
+    <Airport ICAO="YWDL" FullName="Wondoola" Position="-183430.000+1405330.000" Elevation="190" />
     <Airport ICAO="YWEC" FullName="Wellclose" Position="-253246.000+1450807.000" />
     <Airport ICAO="YWEH" FullName="Weipa Heliport" Position="-123819.000+1415137.000" />
-    <Airport ICAO="YWEL" FullName="Wellington" Position="-322745.000+1485926.000" />
-    <Airport ICAO="YWGA" FullName="Port Hedland/Wodgina" Position="-210209.000+1183837.000">
+    <Airport ICAO="YWEL" FullName="Wellington" Position="-322745.000+1485926.000" Elevation="1398" />
+    <Airport ICAO="YWGA" FullName="Port Hedland/Wodgina" Position="-210209.000+1183837.000" Elevation="410">
       <Runway Name="09" Position="-210207.990+1183758.440" />
       <Runway Name="27" Position="-210215.200+1183910.770" />
     </Airport>
     <Airport ICAO="YWGI" FullName="Wedge Island" Position="-351032.000+1362909.000" />
-    <Airport ICAO="YWGM" FullName="White Gum" Position="-315202.000+1165621.000" />
-    <Airport ICAO="YWGN" FullName="Wagin" Position="-331859.000+1172137.000" />
-    <Airport ICAO="YWGT" FullName="Wangaratta" Position="-362457.000+1461825.000">
+    <Airport ICAO="YWGM" FullName="White Gum" Position="-315202.000+1165621.000" Elevation="1000" />
+    <Airport ICAO="YWGN" FullName="Wagin" Position="-331859.000+1172137.000" Elevation="836" />
+    <Airport ICAO="YWGT" FullName="Wangaratta" Position="-362457.000+1461825.000" Elevation="504">
       <Runway Name="09" Position="-362508.160+1461758.620" />
       <Runway Name="27" Position="-362510.540+1461819.830" />
       <Runway Name="18" Position="-362429.920+1461834.820" />
       <Runway Name="36" Position="-362522.530+1461825.400" />
     </Airport>
-    <Airport ICAO="YWHA" FullName="Whyalla" Position="-330332.000+1373052.000">
+    <Airport ICAO="YWHA" FullName="Whyalla" Position="-330332.000+1373052.000" Elevation="41">
       <Runway Name="05" Position="-330331.310+1373025.710" />
       <Runway Name="23" Position="-330307.470+1373105.120" />
       <Runway Name="17" Position="-330304.060+1373106.460" />
       <Runway Name="35" Position="-330358.540+1373112.940" />
     </Airport>
-    <Airport ICAO="YWHC" FullName="White Cliffs" Position="-305105.000+1430424.000">
+    <Airport ICAO="YWHC" FullName="White Cliffs" Position="-305105.000+1430424.000" Elevation="536">
       <Runway Name="02" Position="-305124.790+1430405.490" />
       <Runway Name="20" Position="-305100.360+1430421.840" />
       <Runway Name="12" Position="-305057.000+1430402.710" />
       <Runway Name="30" Position="-305117.580+1430435.590" />
     </Airport>
-    <Airport ICAO="YWHG" FullName="Wahring Field" Position="-364048.000+1451436.000" />
+    <Airport ICAO="YWHG" FullName="Wahring Field" Position="-364048.000+1451436.000" Elevation="410" />
     <Airport ICAO="YWHI" FullName="Witchelina" Position="-300210.000+1380326.000" />
-    <Airport ICAO="YWHP" FullName="Wollongong Heliport" Position="-342622.000+1505346.000" />
+    <Airport ICAO="YWHP" FullName="Wollongong Heliport" Position="-342622.000+1505346.000" Elevation="15" />
     <Airport ICAO="YWIB" FullName="Mount Willoughby" Position="-275900.000+1340900.000" />
     <Airport ICAO="YWIM" FullName="Wieambilla/Kenya" Position="-265626.000+1502733.000" />
-    <Airport ICAO="YWIS" FullName="Williamson" Position="-222824.000+1501042.000" />
-    <Airport ICAO="YWKB" FullName="Warracknabeal" Position="-361916.000+1422510.000">
+    <Airport ICAO="YWIS" FullName="Williamson" Position="-222824.000+1501042.000" Elevation="104" />
+    <Airport ICAO="YWKB" FullName="Warracknabeal" Position="-361916.000+1422510.000" Elevation="397">
       <Runway Name="08" Position="-361919.540+1422446.620" />
       <Runway Name="26" Position="-361916.410+1422541.500" />
       <Runway Name="17" Position="-361902.960+1422505.720" />
       <Runway Name="35" Position="-361927.640+1422508.130" />
     </Airport>
-    <Airport ICAO="YWKI" FullName="Waikerie" Position="-341103.000+1400150.000" />
+    <Airport ICAO="YWKI" FullName="Waikerie" Position="-341103.000+1400150.000" Elevation="138" />
     <Airport ICAO="YWKS" FullName="Wilkins Runway" Position="-664129.000+1113139.000" />
-    <Airport ICAO="YWKW" FullName="Warkworth" Position="-323254.000+1510127.000" />
+    <Airport ICAO="YWKW" FullName="Warkworth" Position="-323254.000+1510127.000" Elevation="250" />
     <Airport ICAO="YWLA" FullName="Willowra" Position="-211636.000+1323724.000" />
-    <Airport ICAO="YWLG" FullName="Walgett" Position="-300158.000+1480733.000">
+    <Airport ICAO="YWLG" FullName="Walgett" Position="-300158.000+1480733.000" Elevation="439">
       <Runway Name="05" Position="-300214.390+1480705.940" />
       <Runway Name="23" Position="-300146.510+1480757.480" />
       <Runway Name="18" Position="-300135.840+1480735.090" />
       <Runway Name="36" Position="-300212.660+1480727.180" />
     </Airport>
-    <Airport ICAO="YWLM" FullName="Williamtown" Position="-324742.000+1515004.000">
+    <Airport ICAO="YWLM" FullName="Williamtown" Position="-324742.000+1515004.000" Elevation="31">
       <Runway Name="12" Position="-324713.640+1514921.340" />
       <Runway Name="30" Position="-324817.850+1515050.990" />
     </Airport>
-    <Airport ICAO="YWLU" FullName="Wiluna" Position="-263745.000+1201314.000">
+    <Airport ICAO="YWLU" FullName="Wiluna" Position="-263745.000+1201314.000" Elevation="1652">
       <Runway Name="15" Position="-263733.310+1201300.980" />
       <Runway Name="33" Position="-263822.410+1201337.010" />
     </Airport>
-    <Airport ICAO="YWMC" FullName="William Creek" Position="-285425.000+1362028.000" />
+    <Airport ICAO="YWMC" FullName="William Creek" Position="-285425.000+1362028.000" Elevation="300" />
     <Airport ICAO="YWMG" FullName="Weilmoringle" Position="-291500.000+1465500.000" />
-    <Airport ICAO="YWMP" FullName="Wrotham Park" Position="-163929.000+1440003.000" />
-    <Airport ICAO="YWND" FullName="Wondai" Position="-261703.000+1515141.000" />
+    <Airport ICAO="YWMP" FullName="Wrotham Park" Position="-163929.000+1440003.000" Elevation="500" />
+    <Airport ICAO="YWND" FullName="Wondai" Position="-261703.000+1515141.000" Elevation="1050" />
     <Airport ICAO="YWON" FullName="Wongalara" Position="-140546.000+1342454.000" />
     <Airport ICAO="YWOW" FullName="Dubbo/Wings Out West" Position="-322017.000+1483142.000" />
     <Airport ICAO="YWPB" FullName="Bayu Undan Whp" Position="-110425.000+1264053.000" />
     <Airport ICAO="YWPN" FullName="Wilpena" Position="-313100.000+1383730.000" />
-    <Airport ICAO="YWRL" FullName="Warialda" Position="-293200.000+1503200.000" />
-    <Airport ICAO="YWRN" FullName="Warren" Position="-314400.000+1474809.000">
+    <Airport ICAO="YWRL" FullName="Warialda" Position="-293200.000+1503200.000" Elevation="1140" />
+    <Airport ICAO="YWRN" FullName="Warren" Position="-314400.000+1474809.000" Elevation="669">
       <Runway Name="03" Position="-314426.390+1474733.010" />
       <Runway Name="21" Position="-314400.550+1474759.290" />
       <Runway Name="09" Position="-314359.820+1474811.340" />
       <Runway Name="27" Position="-314405.870+1474855.960" />
     </Airport>
     <Airport ICAO="YWRO" FullName="Wallaroo" Position="-335537.000+1373816.000" />
-    <Airport ICAO="YWSG" FullName="Watts Bridge" Position="-270544.000+1522735.000" />
-    <Airport ICAO="YWSL" FullName="Westle" Position="-380530.000+1465755.000">
+    <Airport ICAO="YWSG" FullName="Watts Bridge" Position="-270544.000+1522735.000" Elevation="300" />
+    <Airport ICAO="YWSL" FullName="Westle" Position="-380530.000+1465755.000" Elevation="93">
       <Runway Name="05" Position="-380541.250+1465742.730" />
       <Runway Name="23" Position="-380532.230+1465759.840" />
       <Runway Name="09" Position="-380522.940+1465724.230" />
@@ -19620,56 +19636,56 @@ BOFOR
       <Runway Name="32" Position="-380549.130+1465807.300" />
     </Airport>
     <Airport ICAO="YWSR" FullName="Newcastle/Wallsair" Position="-325258.000+1514020.000" />
-    <Airport ICAO="YWST" FullName="Westmead Hospital" Position="-334818.000+1505918.000" />
-    <Airport ICAO="YWTB" FullName="Watsons Bay Helipad" Position="-335006.000+1511650.000" />
+    <Airport ICAO="YWST" FullName="Westmead Hospital" Position="-334818.000+1505918.000" Elevation="127" />
+    <Airport ICAO="YWTB" FullName="Watsons Bay Helipad" Position="-335006.000+1511650.000" Elevation="140" />
     <Airport ICAO="YWTH" FullName="Waterhouse Island" Position="-404704.000+1473827.000" />
-    <Airport ICAO="YWTL" FullName="Waterloo (NT)" Position="-163748.000+1291916.000" />
-    <Airport ICAO="YWTN" FullName="Winton" Position="-222149.000+1430508.000">
+    <Airport ICAO="YWTL" FullName="Waterloo (NT)" Position="-163748.000+1291916.000" Elevation="433" />
+    <Airport ICAO="YWTN" FullName="Winton" Position="-222149.000+1430508.000" Elevation="638">
       <Runway Name="05" Position="-222154.620+1430430.890" />
       <Runway Name="23" Position="-222139.770+1430457.620" />
       <Runway Name="14" Position="-222125.470+1430457.350" />
       <Runway Name="32" Position="-222204.520+1430522.620" />
     </Airport>
-    <Airport ICAO="YWTO" FullName="Wentworth" Position="-340516.000+1415331.000">
+    <Airport ICAO="YWTO" FullName="Wentworth" Position="-340516.000+1415331.000" Elevation="120">
       <Runway Name="08" Position="-340509.980+1415312.140" />
       <Runway Name="26" Position="-340511.190+1415406.750" />
       <Runway Name="17" Position="-340448.910+1415328.400" />
       <Runway Name="35" Position="-340519.280+1415327.790" />
     </Airport>
     <Airport ICAO="YWTP" FullName="Wheatstone Platform" Position="-195548.000+1152303.000" />
-    <Airport ICAO="YWUD" FullName="Wudinna" Position="-330236.000+1352650.000">
+    <Airport ICAO="YWUD" FullName="Wudinna" Position="-330236.000+1352650.000" Elevation="310">
       <Runway Name="07" Position="-330239.850+1352622.590" />
       <Runway Name="25" Position="-330231.670+1352657.480" />
       <Runway Name="14" Position="-330204.010+1352626.160" />
       <Runway Name="32" Position="-330243.830+1352700.060" />
     </Airport>
-    <Airport ICAO="YWVA" FullName="Warnervale" Position="-331425.000+1512549.000" />
-    <Airport ICAO="YWVR" FullName="Wolgan Valley Heliport" Position="-331513.000+1501116.000" />
-    <Airport ICAO="YWWI" FullName="Woodie Woodie" Position="-213843.000+1211130.000">
+    <Airport ICAO="YWVA" FullName="Warnervale" Position="-331425.000+1512549.000" Elevation="25" />
+    <Airport ICAO="YWVR" FullName="Wolgan Valley Heliport" Position="-331513.000+1501116.000" Elevation="1826" />
+    <Airport ICAO="YWWI" FullName="Woodie Woodie" Position="-213843.000+1211130.000" Elevation="887">
       <Runway Name="14" Position="-213818.870+1211106.280" />
       <Runway Name="32" Position="-213909.170+1211150.370" />
     </Airport>
-    <Airport ICAO="YWWL" FullName="West Wyalong" Position="-335614.000+1471129.000">
+    <Airport ICAO="YWWL" FullName="West Wyalong" Position="-335614.000+1471129.000" Elevation="859">
       <Runway Name="04" Position="-335622.910+1471133.740" />
       <Runway Name="22" Position="-335604.000+1471153.850" />
       <Runway Name="09" Position="-335616.890+1471052.330" />
       <Runway Name="27" Position="-335624.610+1471153.340" />
     </Airport>
-    <Airport ICAO="YWYA" FullName="Wyandra" Position="-271600.000+1455924.000" />
+    <Airport ICAO="YWYA" FullName="Wyandra" Position="-271600.000+1455924.000" Elevation="800" />
     <Airport ICAO="YWYB" FullName="Wynbring" Position="-303342.000+1333200.000" />
-    <Airport ICAO="YWYF" FullName="Wycheproof" Position="-360332.000+1431436.000">
+    <Airport ICAO="YWYF" FullName="Wycheproof" Position="-360332.000+1431436.000" Elevation="350">
       <Runway Name="08" Position="-360332.050+1431402.310" />
       <Runway Name="26" Position="-360332.150+1431431.010" />
       <Runway Name="17" Position="-360315.520+1431433.550" />
       <Runway Name="35" Position="-360348.920+1431433.360" />
     </Airport>
-    <Airport ICAO="YWYM" FullName="Wyndham" Position="-153041.000+1280911.000">
+    <Airport ICAO="YWYM" FullName="Wyndham" Position="-153041.000+1280911.000" Elevation="15">
       <Runway Name="12" Position="-153016.000+1280855.590" />
       <Runway Name="30" Position="-153045.390+1280940.120" />
     </Airport>
     <Airport ICAO="YWYO" FullName="Wyoming" Position="-271311.000+1512943.000" />
-    <Airport ICAO="YWYR" FullName="Wyreema" Position="-274003.000+1515116.000" />
-    <Airport ICAO="YWYY" FullName="Wynyard" Position="-405956.000+1454352.000">
+    <Airport ICAO="YWYR" FullName="Wyreema" Position="-274003.000+1515116.000" Elevation="1750" />
+    <Airport ICAO="YWYY" FullName="Wynyard" Position="-405956.000+1454352.000" Elevation="65">
       <Runway Name="05" Position="-405952.230+1454325.440" />
       <Runway Name="23" Position="-405942.240+1454353.140" />
       <Runway Name="09" Position="-405948.390+1454326.260" />
@@ -19768,7 +19784,7 @@ BOFOR
     <Airport ICAO="YXNL" FullName="Northern Beaches Hospital" Position="-334503.000+1511400.000" />
     <Airport ICAO="YXNN" FullName="Nanango Hospital" Position="-263957.000+1520027.000" />
     <Airport ICAO="YXNR" FullName="North Rankin" Position="-193511.000+1160820.000" />
-    <Airport ICAO="YXNS" FullName="Royal North Shore Hospital" Position="-334916.000+1511131.000" />
+    <Airport ICAO="YXNS" FullName="Royal North Shore Hospital" Position="-334916.000+1511131.000" Elevation="363" />
     <Airport ICAO="YXOD" FullName="Oatlands Medical" Position="-421815.000+1472200.000" />
     <Airport ICAO="YXOH" FullName="Coolah Hospital" Position="-314918.000+1494236.000" />
     <Airport ICAO="YXOK" FullName="Crookwell Rfs" Position="-342658.000+1492809.000" />
@@ -19818,27 +19834,27 @@ BOFOR
     <Airport ICAO="YXYR" FullName="Ayr Hospital" Position="-193353.000+1472433.000" />
     <Airport ICAO="YYAL" FullName="Yalgoo" Position="-282113.000+1164044.000" />
     <Airport ICAO="YYBH" FullName="Yarrabah" Position="-165434.000+1455213.000" />
-    <Airport ICAO="YYKI" FullName="Yorke Island" Position="-094512.000+1432418.000">
+    <Airport ICAO="YYKI" FullName="Yorke Island" Position="-094512.000+1432418.000" Elevation="10">
       <Runway Name="12" Position="-094501.930+1432407.060" />
       <Runway Name="30" Position="-094517.150+1432431.660" />
     </Airport>
     <Airport ICAO="YYLP" FullName="Yarloop" Position="-325723.000+1155654.000" />
-    <Airport ICAO="YYMI" FullName="Yam Island" Position="-095354.000+1424618.000" />
-    <Airport ICAO="YYND" FullName="Yuendumu" Position="-221515.000+1314656.000" />
-    <Airport ICAO="YYNG" FullName="Young" Position="-341520.000+1481453.000">
+    <Airport ICAO="YYMI" FullName="Yam Island" Position="-095354.000+1424618.000" Elevation="15" />
+    <Airport ICAO="YYND" FullName="Yuendumu" Position="-221515.000+1314656.000" Elevation="2205" />
+    <Airport ICAO="YYNG" FullName="Young" Position="-341520.000+1481453.000" Elevation="1267">
       <Runway Name="01" Position="-341539.160+1481443.540" />
       <Runway Name="19" Position="-341500.880+1481455.720" />
     </Airport>
-    <Airport ICAO="YYRM" FullName="Yarram" Position="-383403.000+1464516.000">
+    <Airport ICAO="YYRM" FullName="Yarram" Position="-383403.000+1464516.000" Elevation="60">
       <Runway Name="05" Position="-383417.750+1464453.710" />
       <Runway Name="23" Position="-383401.340+1464533.590" />
       <Runway Name="09" Position="-383358.340+1464457.070" />
       <Runway Name="27" Position="-383402.260+1464527.890" />
     </Airport>
-    <Airport ICAO="YYRN" FullName="Yamarna" Position="-280918.000+1234030.000" />
+    <Airport ICAO="YYRN" FullName="Yamarna" Position="-280918.000+1234030.000" Elevation="1449" />
     <Airport ICAO="YYUN" FullName="Yunta" Position="-323418.000+1393350.000" />
     <Airport ICAO="YYWA" FullName="Yowah" Position="-275700.000+1443730.000" />
-    <Airport ICAO="YYWG" FullName="Yarrawonga" Position="-360150.000+1460140.000">
+    <Airport ICAO="YYWG" FullName="Yarrawonga" Position="-360150.000+1460140.000" Elevation="424">
       <Runway Name="01" Position="-360211.690+1460131.370" />
       <Runway Name="19" Position="-360137.940+1460148.530" />
       <Runway Name="05" Position="-360154.720+1460123.330" />

--- a/Maps/APP_RNP(AR).xml
+++ b/Maps/APP_RNP(AR).xml
@@ -49,11 +49,8 @@
       <Point>SADMI</Point>
       <Point>OGUGU</Point>
       <Point>TUMDI</Point>
-      <Point>WOKKI</Point>
       <Point>KITTY</Point>
       <Point>UPSEN</Point>
-      <Point>NASUX</Point>
-      <Point>LAPAR</Point>
       <Point>GITSM</Point>
       <Point>GORGN</Point>
       <Point>HOORN</Point>
@@ -98,7 +95,6 @@
       <Point>AREXO</Point>
       <Point>AD030</Point>
       <Point>DN404</Point>
-      <Point>DN432</Point>
       <Point>KA902</Point>
       <Point>KA904</Point>
       <Point>PH020</Point>
@@ -213,16 +209,13 @@
       <Point>HB420</Point>
       <Point>HB520</Point>
       <Point>ML420</Point>
-      <Point>GUPOD</Point>
-      <Point>DN422</Point>
-      <Point>ADBER</Point>
-      <Point>DN438</Point>
       <Point>TOSOB</Point>
       <Point>DN412</Point>
       <Point>IGBOV</Point>
       <Point>GUMUR</Point>
       <Point>DN448</Point>
       <Point>DN444</Point>
+      <Point>DN432</Point>
       <Point>KA922</Point>
       <Point>KA918</Point>
       <Point>KA910</Point>
@@ -294,11 +287,8 @@
       <Point>SADMI</Point>
       <Point>OGUGU</Point>
       <Point>TUMDI</Point>
-      <Point>WOKKI</Point>
       <Point>KITTY</Point>
       <Point>UPSEN</Point>
-      <Point>NASUX</Point>
-      <Point>LAPAR</Point>
       <Point>GITSM</Point>
       <Point>GORGN</Point>
       <Point>HOORN</Point>
@@ -345,7 +335,6 @@
       <Point>AREXO</Point>
       <Point>AD030</Point>
       <Point>DN404</Point>
-      <Point>DN432</Point>
       <Point>KA902</Point>
       <Point>KA904</Point>
       <Point>PH020</Point>
@@ -473,14 +462,10 @@
     <Line>AD020/AD030</Line>
     <Line>OGUGU/AD020</Line>
     <Line>TUMDI/AD030</Line>
-    <Line>WOKKI/GUPOD/-12.315856+130.850623/DN422/-12.297763+130.780359/-12.307081+130.760450/-12.324876+130.747975/-12.346380+130.746278/-12.365832+130.755816/-12.375647+130.768511/DN404/DN11T</Line>
-    <Line>WOKKI/ADBER/DN438/-12.369144+131.009905/-12.381301+131.028133/-12.400751+131.037678/-12.422256+131.035987/-12.440053+131.023511/-12.449374+131.003593/-12.449772+130.990766/DN432/DN29T</Line>
-    <Line>DN407/-12.427845+130.719496/-12.406295+130.720395/-12.388086+130.732230/-12.378095+130.751800/-12.377467+130.766602/DN404</Line>
+    <Line>DN407/-12.427845+130.719496/-12.406295+130.720395/-12.388086+130.732230/-12.378095+130.751800/-12.377467+130.766602/DN404/DN11T</Line>
     <Line>KITTY/TOSOB/DN412/-12.457633+130.746873/-12.452737+130.736928/-12.445472+130.728637/-12.436359+130.722556/-12.435797+130.722317/DN407</Line>
     <Line>UPSEN/IGBOV/DN407</Line>
-    <Line>KITTY/GUMUR/DN448/-12.533533+130.973599/-12.535214+130.995618/-12.525893+131.015543/-12.508096+131.028022/-12.486591+131.029714/-12.467141+131.020166/-12.458983+131.010424/DN444/DN432</Line>
-    <Line>NASUX/DN404</Line>
-    <Line>LAPAR/DN432</Line>
+    <Line>KITTY/GUMUR/DN448/-12.533533+130.973599/-12.535214+130.995618/-12.525893+131.015543/-12.508096+131.028022/-12.486591+131.029714/-12.467141+131.020166/-12.458983+131.010424/DN444/DN432/DN29T</Line>
     <Line>KA902/KA08T</Line>
     <Line>GITSM/KA922/-20.698309+116.866233/-20.712055+116.822158/-20.736110+116.783396/-20.768723+116.752598/-20.777899+116.746583/KA918/-20.792404+116.738494/-20.805414+116.731018/-20.816165+116.720147/-20.823919+116.706669/-20.828147+116.691502/-20.828560+116.675681/-20.825333+116.660979/KA910/MURAY/-20.773650+116.625861/-20.760721+116.627869/-20.748743+116.633417/-20.738516+116.642089/-20.730736+116.653295/-20.728838+116.657426/KA902</Line>
     <Line>GORGN/KA902</Line>

--- a/Maps/APP_RNP_ALL.xml
+++ b/Maps/APP_RNP_ALL.xml
@@ -174,6 +174,9 @@
       <Point>PADEK</Point>
       <Point>PADEL</Point>
       <Point>PADEN</Point>
+      <Point>KITTY</Point>
+      <Point>UPSEN</Point>
+      <Point>WOKKI</Point>
       <Point>DRWWD</Point>
       <Point>DRWWE</Point>
       <Point>DRWWG</Point>
@@ -228,12 +231,12 @@
       <Point>STWEA</Point>
       <Point>STWEB</Point>
       <Point>STWEC</Point>
-      <Point>WM2WA</Point>
-      <Point>WM2WB</Point>
-      <Point>WM2WC</Point>
       <Point>WM2ED</Point>
       <Point>WM2EE</Point>
       <Point>WM2EG</Point>
+      <Point>WM2WA</Point>
+      <Point>WM2WB</Point>
+      <Point>WM2WC</Point>
       <Point>BAFWF</Point>
       <Point>BAFEF</Point>
       <Point>BASWF</Point>
@@ -286,6 +289,8 @@
       <Point>PADWF</Point>
       <Point>PADNF</Point>
       <Point>PADEF</Point>
+      <Point>DN404</Point>
+      <Point>DN432</Point>
       <Point>DRWWF</Point>
       <Point>DRWEF</Point>
       <Point>DRWSF</Point>
@@ -311,8 +316,8 @@
       <Point>SSYSF</Point>
       <Point>STWWF</Point>
       <Point>STWEF</Point>
-      <Point>WM2WF</Point>
       <Point>WM2EF</Point>
+      <Point>WM2WF</Point>
       <Point>BAFWI</Point>
       <Point>BAFEI</Point>
       <Point>BASWI</Point>
@@ -362,6 +367,8 @@
       <Point>PADWI</Point>
       <Point>PADNI</Point>
       <Point>PADEI</Point>
+      <Point>NASUX</Point>
+      <Point>LAPAR</Point>
       <Point>DRWWI</Point>
       <Point>DRWEI</Point>
       <Point>DRWSI</Point>
@@ -380,8 +387,8 @@
       <Point>SCNWI</Point>
       <Point>STWWI</Point>
       <Point>STWEI</Point>
-      <Point>WM2WI</Point>
       <Point>WM2EI</Point>
+      <Point>WM2WI</Point>
       <Point>AG2ND</Point>
       <Point>AG2NE</Point>
       <Point>AG2NG</Point>
@@ -3127,6 +3134,8 @@
       <Point>PADWF</Point>
       <Point>PADNF</Point>
       <Point>PADEF</Point>
+      <Point>DN404</Point>
+      <Point>DN432</Point>
       <Point>DRWWF</Point>
       <Point>DRWEF</Point>
       <Point>DRWSF</Point>
@@ -3152,8 +3161,8 @@
       <Point>SSYSF</Point>
       <Point>STWWF</Point>
       <Point>STWEF</Point>
-      <Point>WM2WF</Point>
       <Point>WM2EF</Point>
+      <Point>WM2WF</Point>
       <Point>AG2NF</Point>
       <Point>AG2SF</Point>
       <Point>ALHWF</Point>
@@ -3768,6 +3777,8 @@
       <Point>PADWI</Point>
       <Point>PADNI</Point>
       <Point>PADEI</Point>
+      <Point>NASUX</Point>
+      <Point>LAPAR</Point>
       <Point>DRWWI</Point>
       <Point>DRWEI</Point>
       <Point>DRWSI</Point>
@@ -3786,8 +3797,8 @@
       <Point>SCNWI</Point>
       <Point>STWWI</Point>
       <Point>STWEI</Point>
-      <Point>WM2WI</Point>
       <Point>WM2EI</Point>
+      <Point>WM2WI</Point>
       <Point>AG2NI</Point>
       <Point>AG2SI</Point>
       <Point>ALHWI</Point>
@@ -4512,6 +4523,9 @@
       <Point>PADEK</Point>
       <Point>PADEL</Point>
       <Point>PADEN</Point>
+      <Point>KITTY</Point>
+      <Point>UPSEN</Point>
+      <Point>WOKKI</Point>
       <Point>DRWWD</Point>
       <Point>DRWWE</Point>
       <Point>DRWWG</Point>
@@ -4565,12 +4579,12 @@
       <Point>STWEA</Point>
       <Point>STWEB</Point>
       <Point>STWEC</Point>
-      <Point>WM2WA</Point>
-      <Point>WM2WB</Point>
-      <Point>WM2WC</Point>
       <Point>WM2ED</Point>
       <Point>WM2EE</Point>
       <Point>WM2EG</Point>
+      <Point>WM2WA</Point>
+      <Point>WM2WB</Point>
+      <Point>WM2WC</Point>
       <Point>AG2ND</Point>
       <Point>AG2NE</Point>
       <Point>AG2NG</Point>
@@ -9083,6 +9097,13 @@
     <Line>PADEK/PADEI</Line>
     <Line>PADEL/PADEI</Line>
     <Line>PADEN/PADEI</Line>
+    <Line>NASUX/DN404</Line>
+    <Line>KITTY/TOSOB/DN412/-12.457634+130.746873/-12.445785+130.728423/-12.426499+130.718536/-12.404968+130.719849/-12.386964+130.732008/-12.377308+130.751753/-12.378339+130.772910/DN404/NASUX</Line>
+    <Line>UPSEN/IGBOV/DN407/-12.427845+130.719496/-12.406284+130.720009/-12.387876+130.731518/-12.377552+130.750906/-12.378079+130.772981/-12.378420+130.774016/DN404/NASUX</Line>
+    <Line>WOKKI/GUPOD/DN422/-12.299439+130.802345/-12.298133+130.780316/-12.307789+130.760577/-12.325794+130.748422/-12.347324+130.747109/-12.366610+130.756993/-12.378485+130.775426/-12.378693+130.776182/DN404/NASUX</Line>
+    <Line>LAPAR/DN444/DN432</Line>
+    <Line>KITTY/GUMUR/DN448/-12.533533+130.973599/-12.534838+130.995644/-12.525180+131.015399/-12.507172+131.027559/-12.485641+131.028866/-12.466358+131.018972/-12.454806+131.001392/DN444/DN432/LAPAR</Line>
+    <Line>WOKKI/ADBER/DN438/-12.369144+131.009905/-12.380988+131.028348/-12.400272+131.038238/-12.421803+131.036932/-12.439810+131.024776/-12.449469+131.005028/-12.448190+130.982979/-12.447914+130.982246/DN432/LAPAR</Line>
     <Line>DRWWI/DRWWF/DN11T</Line>
     <Line>DRWWD/DRWWI</Line>
     <Line>DRWWE/DRWWI</Line>
@@ -9168,13 +9189,13 @@
     <Line>STWEA/STWEI</Line>
     <Line>STWEB/STWEI</Line>
     <Line>STWEC/STWEI</Line>
-    <Line>WM2WI/WM2WF/WL12T</Line>
-    <Line>WM2WA/WM2WI</Line>
-    <Line>WM2WB/WM2WI</Line>
-    <Line>WM2WC/WM2WI</Line>
     <Line>WM2EI/WM2EF/WL30T</Line>
     <Line>WM2ED/WM2EI</Line>
     <Line>WM2EE/WM2EI</Line>
     <Line>WM2EG/WM2EI</Line>
+    <Line>WM2WI/WM2WF/WL12T</Line>
+    <Line>WM2WA/WM2WI</Line>
+    <Line>WM2WB/WM2WI</Line>
+    <Line>WM2WC/WM2WI</Line>
   </Map>
 </Maps>

--- a/Maps/APP_RNP_ALL.xml
+++ b/Maps/APP_RNP_ALL.xml
@@ -1368,6 +1368,15 @@
       <Point>HSMWG</Point>
       <Point>HSMWF</Point>
       <Point>HSMWI</Point>
+      <Point>HT2ED</Point>
+      <Point>HT2EE</Point>
+      <Point>HT2EF</Point>
+      <Point>HT2EI</Point>
+      <Point>HT2WA</Point>
+      <Point>HT2WB</Point>
+      <Point>HT2WC</Point>
+      <Point>HT2WF</Point>
+      <Point>HT2WI</Point>
       <Point>HXXND</Point>
       <Point>HXXNE</Point>
       <Point>HXXNG</Point>
@@ -3365,6 +3374,8 @@
       <Point>HOZEF</Point>
       <Point>HSMEF</Point>
       <Point>HSMWF</Point>
+      <Point>HT2EF</Point>
+      <Point>HT2WF</Point>
       <Point>HXXNF</Point>
       <Point>HXXSF</Point>
       <Point>IA2EF</Point>
@@ -4001,6 +4012,8 @@
       <Point>HOZEI</Point>
       <Point>HSMEI</Point>
       <Point>HSMWI</Point>
+      <Point>HT2EI</Point>
+      <Point>HT2WI</Point>
       <Point>HXXNI</Point>
       <Point>HXXSI</Point>
       <Point>IA2EI</Point>
@@ -5161,6 +5174,11 @@
       <Point>HSMWD</Point>
       <Point>HSMWE</Point>
       <Point>HSMWG</Point>
+      <Point>HT2ED</Point>
+      <Point>HT2EE</Point>
+      <Point>HT2WA</Point>
+      <Point>HT2WB</Point>
+      <Point>HT2WC</Point>
       <Point>HXXND</Point>
       <Point>HXXNE</Point>
       <Point>HXXNG</Point>
@@ -7151,6 +7169,15 @@
     <Line>HSMWG/HSMWI</Line>
     <Line>HSMWI/HSMWF</Line>
     <Line>HSMWM/HSMWF</Line>
+    <Line>HT2ED/HT2EI</Line>
+    <Line>HT2EE/HT2EI</Line>
+    <Line>HT2EI/HT2EF</Line>
+    <Line>-200224.270+1461651.570/HT2EF</Line>
+    <Line>HT2WA/HT2WI</Line>
+    <Line>HT2WB/HT2WI</Line>
+    <Line>HT2WC/HT2WI</Line>
+    <Line>HT2WI/HT2WF</Line>
+    <Line>-200251.060+1461558.990/HT2WF</Line>
     <Line>HXXND/HXXNI</Line>
     <Line>HXXNE/HXXNI</Line>
     <Line>HXXNG/HXXNI</Line>

--- a/Profile.xml
+++ b/Profile.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Profile Name="Australia" FullName="Eurocat Australia (YMMM/YBBB)">
-	<Version AIRAC="2206" Revision="b" PublishDate="20220616" UpdateURL="https://vatsys.sawbe.com/downloads/data/Australia" />
+	<Version AIRAC="2207" Revision="a" PublishDate="20220714" UpdateURL="https://vatsys.sawbe.com/downloads/data/Australia" />
 	<Servers>
 		<VATSIMStatus url="https://status.vatsim.net/" />
 		<GRIB url="https://sawbe.com/GRIB/" />


### PR DESCRIPTION
AIRAC 2207 Changes:

- New STAR: YSCB RWY 35 BUNGO 4 WHISKEY (Non-jet)
- New STAR: YSCB RWY 17 and 35 BUNGO 4 YANKEY (Non-jet)
- YSCB BUNGO VICTOR STAR increase validity indicator to FOUR
- YPDN new RNAV (RNP) RWY 11
- YPDN new RNAV (RNP) RWY 29
- YPDN updated RNAV-Y (RNP) RWY 11 and 29
- YWLM displaced runway threshold RWY 30 (Rename RNAV (RNP) RWY 30 to RNAV-Z (RNP) RWY 30)
- YCHT New RNP RWY 06