### PR TITLE
Fixed swapped CVN & GVE labels

### DIFF
--- a/Maps/SECTOR_FREQS.xml
+++ b/Maps/SECTOR_FREQS.xml
@@ -43,7 +43,7 @@
       <Point Name="WRA 132.9">-272024.000+1372305.000</Point>
       <Point Name="ESP 123.95">-354427.000+1215735.000</Point>
       <Point Name="LEA 122.4">-303453.000+1142531.000</Point>
-      <Point Name="GVE 133.8">-245100.000+1483800.000</Point>
+      <Point Name="GVE 133.8">-290800.000+1173200.000</Point>
       <Point Name="CRS 135.8">-305600.000+1185800.000</Point>
       <Point Name="HYD 118.2">-323100.000+1185300.000</Point>
       <Point Name="JAR 120.3">-341200.000+1163000.000</Point>
@@ -68,7 +68,7 @@
       <Point Name="KIY 133.4">-174400.000+1251900.000</Point>
       <Point Name="STR 134.4">-183000.000+1342600.000</Point>
       <Point Name="MDE 133.0">-300718.000+1484202.000</Point>
-      <Point Name="CVN 133.8">-290800.000+1173200.000</Point>
+      <Point Name="CVN 133.8">-245100.000+1483800.000</Point>
       <Point Name="CNK 123.4">-330156.424+1505757.132</Point>
       <Point Name="MNN 130.1">-314908.724+1521016.356</Point>
       <Point Name="MLD 132.35">-330354.396+1514429.040</Point>


### PR DESCRIPTION
Fixes https://github.com/vatSys/australia-dataset/issues/95 by replacing CVN/GVE's coordinates with each other's in Sector_Freqs.xml