### PR TITLE
Add FMP positions & HUO TMA sectors

### DIFF
--- a/Positions.xml
+++ b/Positions.xml
@@ -45,6 +45,8 @@
     <Position Name="Huon" Type="ASD" DefaultCenter="-4117.000+14626.000" DefaultRange="800" VisibilityRange="600">
       <Sectors>
         <Sector Name="HUO" />
+        <Sector Name="HBA" />
+        <Sector Name="LTA" />
       </Sectors>
       <ManualVisibility>
         <Point>-41.115+146.038</Point>
@@ -1356,6 +1358,12 @@
         <Line>Charts - vats.im/pac/charts</Line>
         <Line>ATC feedback - helpdesk.vatpac.org</Line>
       </ControllerInfo>
+      <ControllerInfo Callsign="AD_FMP">
+        <Line>Adelaide Flow</Line>
+        <Line>ATIS available on 134.5</Line>
+        <Line>Charts - vats.im/pac/charts</Line>
+        <Line>ATC feedback - helpdesk.vatpac.org</Line>
+      </ControllerInfo>
     </Position>
     <Position Name="Amberley TCU" Type="ASD" DefaultCenter="-27.640556+152.711944" DefaultRange="150" MagneticVariation="-11">
       <Sectors>
@@ -1473,6 +1481,12 @@
         <Line>Charts - vats.im/pac/charts</Line>
         <Line>ATC feedback - helpdesk.vatpac.org</Line>
       </ControllerInfo>
+      <ControllerInfo Callsign="ML_FMP">
+        <Line>Melbourne Flow</Line>
+        <Line>ATIS available on 118.0</Line>
+        <Line>Charts - vats.im/pac/charts</Line>
+        <Line>ATC feedback - helpdesk.vatpac.org</Line>
+      </ControllerInfo>
     </Position>
     <Position Name="Sydney TCU" Type="ASD" DefaultCenter="-33.9461+151.1772" DefaultRange="190" VisibilityRange="100" MagneticVariation="-13">
       <Sectors>
@@ -1552,6 +1566,12 @@
         <Line>Charts - vats.im/pac/charts</Line>
         <Line>ATC feedback - helpdesk.vatpac.org</Line>
       </ControllerInfo>
+      <ControllerInfo Callsign="SY_FMP">
+        <Line>Sydney Flow</Line>
+        <Line>ATIS available on 126.25</Line>
+        <Line>Charts - vats.im/pac/charts</Line>
+        <Line>ATC feedback - helpdesk.vatpac.org</Line>
+      </ControllerInfo>
     </Position>
     <Position Name="Brisbane TCU" Type="ASD" DefaultCenter="-27.648889+153.039167" DefaultRange="220" VisibilityRange="100" MagneticVariation="-11">
       <Sectors>
@@ -1620,6 +1640,12 @@
         <Line>Charts - vats.im/pac/charts</Line>
         <Line>ATC feedback - helpdesk.vatpac.org</Line>
       </ControllerInfo>
+      <ControllerInfo Callsign="BN_FMP">
+        <Line>Brisbane Flow</Line>
+        <Line>ATIS available on 125.5</Line>
+        <Line>Charts - vats.im/pac/charts</Line>
+        <Line>ATC feedback - helpdesk.vatpac.org</Line>
+      </ControllerInfo>
     </Position>
     <Position Name="Canberra TCU" Type="ASD" DefaultCenter="-35.306944+149.195" DefaultRange="150" VisibilityRange="100" MagneticVariation="-12.5">
       <Sectors>
@@ -1657,6 +1683,12 @@
       </ControllerInfo>
       <ControllerInfo Callsign="CB-W_APP">
         <Line>Canberra Approach (West)</Line>
+        <Line>ATIS available on 127.45</Line>
+        <Line>Charts - vats.im/pac/charts</Line>
+        <Line>ATC feedback - helpdesk.vatpac.org</Line>
+      </ControllerInfo>
+      <ControllerInfo Callsign="CB_FMP">
+        <Line>Canberra Flow</Line>
         <Line>ATIS available on 127.45</Line>
         <Line>Charts - vats.im/pac/charts</Line>
         <Line>ATC feedback - helpdesk.vatpac.org</Line>
@@ -1704,6 +1736,12 @@
         <Line>Charts - vats.im/pac/charts</Line>
         <Line>ATC feedback - helpdesk.vatpac.org</Line>
       </ControllerInfo>
+      <ControllerInfo Callsign="PH_FMP">
+        <Line>Perth Flow</Line>
+        <Line>ATIS available on 123.8</Line>
+        <Line>Charts - vats.im/pac/charts</Line>
+        <Line>ATC feedback - helpdesk.vatpac.org</Line>
+      </ControllerInfo>
       <ControllerInfo Callsign="PE_APP">
         <Line>Pearce Approach</Line>
         <Line>ATIS available on 136.4</Line>
@@ -1744,6 +1782,12 @@
       </ControllerInfo>
       <ControllerInfo Callsign="CS-W_APP">
         <Line>Cairns Approach (West)</Line>
+        <Line>ATIS available on 131.1</Line>
+        <Line>Charts - vats.im/pac/charts</Line>
+        <Line>ATC feedback - helpdesk.vatpac.org</Line>
+      </ControllerInfo>
+      <ControllerInfo Callsign="CS_FMP">
+        <Line>Cairns Flow</Line>
         <Line>ATIS available on 131.1</Line>
         <Line>Charts - vats.im/pac/charts</Line>
         <Line>ATC feedback - helpdesk.vatpac.org</Line>

--- a/Positions.xml
+++ b/Positions.xml
@@ -1360,8 +1360,7 @@
       </ControllerInfo>
       <ControllerInfo Callsign="AD_FMP">
         <Line>Adelaide Flow</Line>
-        <Line>ATIS available on 134.5</Line>
-        <Line>Charts - vats.im/pac/charts</Line>
+        <Line>Tactical planning position - no control service offered</Line>
         <Line>ATC feedback - helpdesk.vatpac.org</Line>
       </ControllerInfo>
     </Position>
@@ -1483,8 +1482,7 @@
       </ControllerInfo>
       <ControllerInfo Callsign="ML_FMP">
         <Line>Melbourne Flow</Line>
-        <Line>ATIS available on 118.0</Line>
-        <Line>Charts - vats.im/pac/charts</Line>
+        <Line>Tactical planning position - no control service offered</Line>
         <Line>ATC feedback - helpdesk.vatpac.org</Line>
       </ControllerInfo>
     </Position>
@@ -1568,8 +1566,7 @@
       </ControllerInfo>
       <ControllerInfo Callsign="SY_FMP">
         <Line>Sydney Flow</Line>
-        <Line>ATIS available on 126.25</Line>
-        <Line>Charts - vats.im/pac/charts</Line>
+        <Line>Tactical planning position - no control service offered</Line>
         <Line>ATC feedback - helpdesk.vatpac.org</Line>
       </ControllerInfo>
     </Position>
@@ -1642,8 +1639,7 @@
       </ControllerInfo>
       <ControllerInfo Callsign="BN_FMP">
         <Line>Brisbane Flow</Line>
-        <Line>ATIS available on 125.5</Line>
-        <Line>Charts - vats.im/pac/charts</Line>
+        <Line>Tactical planning position - no control service offered</Line>
         <Line>ATC feedback - helpdesk.vatpac.org</Line>
       </ControllerInfo>
     </Position>
@@ -1689,8 +1685,7 @@
       </ControllerInfo>
       <ControllerInfo Callsign="CB_FMP">
         <Line>Canberra Flow</Line>
-        <Line>ATIS available on 127.45</Line>
-        <Line>Charts - vats.im/pac/charts</Line>
+        <Line>Tactical planning position - no control service offered</Line>
         <Line>ATC feedback - helpdesk.vatpac.org</Line>
       </ControllerInfo>
     </Position>
@@ -1738,8 +1733,7 @@
       </ControllerInfo>
       <ControllerInfo Callsign="PH_FMP">
         <Line>Perth Flow</Line>
-        <Line>ATIS available on 123.8</Line>
-        <Line>Charts - vats.im/pac/charts</Line>
+        <Line>Tactical planning position - no control service offered</Line>
         <Line>ATC feedback - helpdesk.vatpac.org</Line>
       </ControllerInfo>
       <ControllerInfo Callsign="PE_APP">
@@ -1788,8 +1782,7 @@
       </ControllerInfo>
       <ControllerInfo Callsign="CS_FMP">
         <Line>Cairns Flow</Line>
-        <Line>ATIS available on 131.1</Line>
-        <Line>Charts - vats.im/pac/charts</Line>
+        <Line>Tactical planning position - no control service offered</Line>
         <Line>ATC feedback - helpdesk.vatpac.org</Line>
       </ControllerInfo>
     </Position>


### PR DESCRIPTION
Adds FMP positions as selectable options, and adds HBA & LTA to HUO sector list by default.