### PR TITLE
Add waypoint symbols to SY maps

### DIFF
--- a/Maps/Sydney/SY_RWY07.xml
+++ b/Maps/Sydney/SY_RWY07.xml
@@ -111,6 +111,8 @@
       <Point>BIGEM</Point>
       <Point>TAMMI</Point>
       <Point>BOOGI</Point>
+      <Point>KAMBA</Point>
+      <Point>PEGSU</Point>
     </Symbol>
     <!--(SY) RWY07 Airspace-->
     <Line Name="(SY) RWY07" Width="1.7" Pattern="Dotted">

--- a/Maps/Sydney/SY_RWY16PROPS.xml
+++ b/Maps/Sydney/SY_RWY16PROPS.xml
@@ -214,6 +214,8 @@
       <Point>BOOGI</Point>
       <Point>DALAR</Point>
       <Point>DUMOP</Point>
+      <Point>KAMBA</Point>
+      <Point>PEGSU</Point>
     </Symbol>
     <!--(SY) RWY16PROPS Airspace-->
     <Line Name="(SY) RWY16PROPS" Width="1.7" Pattern="Dotted">

--- a/Maps/Sydney/SY_RWY25.xml
+++ b/Maps/Sydney/SY_RWY25.xml
@@ -78,6 +78,8 @@
       <Point>BIGEM</Point>
       <Point>TAMMI</Point>
       <Point>BOOGI</Point>
+      <Point>KAMBA</Point>
+      <Point>PEGSU</Point>
     </Symbol>
     <!--(SY) RWY25 Airspace-->
     <Line Name="(SY) RWY25" Width="1.7" Pattern="Dotted">

--- a/Maps/Sydney/SY_RWY34PROPS.xml
+++ b/Maps/Sydney/SY_RWY34PROPS.xml
@@ -198,6 +198,8 @@
       <Point>MAJAR</Point>
       <Point>DIPPA</Point>
       <Point>MANFA</Point>
+      <Point>KAMBA</Point>
+      <Point>PEGSU</Point>
     </Symbol>
     <!--(SY) RWY34PROPS Airspace-->
     <Line Name="(SY) RWY34PROPS" Width="1.7" Pattern="Dotted">

--- a/Maps/Sydney/SY_RWYCURFEW.xml
+++ b/Maps/Sydney/SY_RWYCURFEW.xml
@@ -130,6 +130,8 @@
       <Point>BIGEM</Point>
       <Point>TAMMI</Point>
       <Point>BOOGI</Point>
+      <Point>KAMBA</Point>
+      <Point>PEGSU</Point>
     </Symbol>
   </Map>
   <Map Type="System" Name="SY_RWYCURFEW_NAMES" Priority="2" Center="-33.946111+151.177222">

--- a/Maps/Sydney/SY_RWYSODPROPS.xml
+++ b/Maps/Sydney/SY_RWYSODPROPS.xml
@@ -155,6 +155,8 @@
       <Point>BIGEM</Point>
       <Point>TAMMI</Point>
       <Point>BOOGI</Point>
+      <Point>KAMBA</Point>
+      <Point>PEGSU</Point>
     </Symbol>
     <!--(SY) RWYSODPROPS Airspace-->
     <Line Name="(SY) RWYSODPROPS_SDN" Width="1.7" Pattern="Dotted">


### PR DESCRIPTION
Adds waypoint symbols to KAMBA and PEGSU (non-jet outbound airway commencement points) on all Sydney airspace maps. Will likely be used in upcoming SOPs update requiring controllers to identify these points.