### PR TITLE
Update ATIS.xml with VCTS definition

### DIFF
--- a/ATIS.xml
+++ b/ATIS.xml
@@ -358,6 +358,7 @@
     <Translation String="VCSH" Spoken="showers in area" />
     <Translation String="SIA" Spoken="showers in area" />
     <Translation String="TS" Spoken="thunderstorm" />
+    <Translation String="VCTS" Spoken="thunderstorms in area" />
     <Translation String="TSRA" Spoken="thunderstorms and rain" />
     <Translation String="TSRAGS" Spoken="thunderstorms and rain with hail" />
     <Translation String="TCU" Spoken="towering cumulus" />


### PR DESCRIPTION
Adds "VCTS" ATIS.xml definition

Noticed when controlling the other day that the new ATIS contained "VCTS" and this was pronounced as such.
While the "VC" infers "vicinity", I have followed the convention used by other definitions such as "VCSH" where by "in area" is used instead.