### PR TITLE
Add space for RWY in PDC

### DIFF
--- a/CPDLC.xml
+++ b/CPDLC.xml
@@ -128,7 +128,7 @@
   <Category name="PDC" AutoloadElements="true" SendViaTM="true">
     <Message Response="NE">PDC [TIMESTAMP]</Message>
     <Message Response="NE">[CALLSIGN] [ATYPE] [ADEP] [ETD]</Message>
-    <Message Response="NE">CLEARED TO [ADES] VIA [SID] DEP [TEXT]</Message>
+    <Message Response="NE">CLEARED TO [ADES] VIA [TEXT] [SID] DEP [TEXT]</Message>
     <Message Response="NE">ROUTE [ROUTE]</Message>
     <Message Response="NE">CLIMB VIA SID TO [LEVEL]</Message>
     <Message Response="NE">DEP FREQ [FREQUENCY]</Message>


### PR DESCRIPTION
Have confirmed that there's no dedicated autofill property for departure runway, so have added a blank `[TEXT]` element which can optionally be used by controllers to add the departure runway, as per recent discussions.