### PR TITLE
fix: Remove label and strip items for CPDLC Plugin

### DIFF
--- a/Labels.xml
+++ b/Labels.xml
@@ -49,22 +49,9 @@
     </DataLine>
     <DataLine>
       <Item Type="LABEL_ITEM_ACID" Colour="" P1_Colour="Warning" P1_BackgroundColour="Emergency" LeftClick="Label_ACID_Menu" MiddleClick="Label_Extend_Toggle" RightClick="Label_SAR_Popup" />
-
-      <!-- Default text status item -->
-      <!-- TODO: Remove once CPDLC plugin is in -->
-      <Item Type="LABEL_ITEM_CPDLC" Colour="" BackgroundColour="CPDLCDownlink" LeftClick="Label_CPDLC_Menu" MiddleClick="Label_CPDLC_Message_Toggle" RightClick="Label_CPDLC_Editor" />
-
-      <!-- CPDLC Plugin: CPDLC Status -->
-      <Item Type="CPDLCPLUGIN_CPDLCSTATUS" />
-      <Item Type="CPDLCPLUGIN_CPDLCSTATUS_BG" BackgroundColour="Custom" />
-
       <Item Type="LABEL_ITEM_CPDLC" Colour="" BackgroundColour="CPDLCDownlink" LeftClick="Label_CPDLC_Menu" MiddleClick="Label_CPDLC_Message_Toggle" RightClick="Label_CPDLC_Editor" />
       <Item Type="LABEL_ITEM_WAKETURBCAT" Colour="" LeftClick="" MiddleClick="" RightClick="" />
       <Item Type="LABEL_ITEM_FIELD18RMK" Colour="" LeftClick="Label_Field18_Popup" MiddleClick="" RightClick="" />
-
-      <!-- CPDLC Plugin: Text Status -->
-      <Item Type="CPDLCPLUGIN_TEXTSTATUS" />
-      <Item Type="CPDLCPLUGIN_TEXTSTATUS_BG" BackgroundColour="Custom" />
     </DataLine>
     <DataLine>
       <Item Type="LABEL_ITEM_LEVEL" Colour="" LeftClick="Label_PRL_Popup" MiddleClick="" RightClick="Label_Move" />
@@ -95,21 +82,9 @@
     </DataLine>
     <DataLine>
       <Item Type="LABEL_ITEM_ACID" Colour="" P1_Colour="Warning" P1_BackgroundColour="Emergency" LeftClick="Label_ACID_Menu" MiddleClick="Label_Extend_Toggle" RightClick="Label_SAR_Popup" />
-      
-      <!-- Default text status item -->
-      <!-- TODO: Remove once CPDLC plugin is in -->
       <Item Type="LABEL_ITEM_CPDLC" Colour="" BackgroundColour="CPDLCDownlink" LeftClick="Label_CPDLC_Menu" MiddleClick="Label_CPDLC_Message_Toggle" RightClick="Label_CPDLC_Editor" />
-
-      <!-- CPDLC Plugin: CPDLC Status -->
-      <Item Type="CPDLCPLUGIN_CPDLCSTATUS" />
-      <Item Type="CPDLCPLUGIN_CPDLCSTATUS_BG" BackgroundColour="Custom" />
-
       <Item Type="LABEL_ITEM_WAKETURBCAT" Colour="" LeftClick="" MiddleClick="" RightClick="" />
       <Item Type="LABEL_ITEM_FIELD18RMK" Colour="" LeftClick="Label_Field18_Popup" MiddleClick="" RightClick="" />
-
-      <!-- CPDLC Plugin: Text Status -->
-      <Item Type="CPDLCPLUGIN_TEXTSTATUS" />
-      <Item Type="CPDLCPLUGIN_TEXTSTATUS_BG" BackgroundColour="Custom" />
     </DataLine>
     <DataLine>
       <Item Type="LABEL_ITEM_LEVEL" Colour="" LeftClick="Label_PRL_Popup" MiddleClick="" RightClick="Label_Move" />

--- a/Strips.xml
+++ b/Strips.xml
@@ -32,17 +32,7 @@
                       <StripLayoutLine>
                         <StripItems>
                           <StripItem Type="Callsign" LeftClick="Label_ACID_Menu" MiddleClick="Strip_Extend" RightClick="Label_SAR_Popup" MaxLength="8" MinLength="8" FontSize="Large" />
-                          
-                          <!-- Default text status item -->
-                          <!-- TODO: Remove once CPDLC plugin is in -->
                           <StripItem Type="CPDLCStatus" LeftClick="Label_CPDLC_Editor" MinLength="1" />
-
-                          <!-- CPDLC Plugin: CPDLC Status -->
-                          <StripItem Type="CPDLCPLUGIN_CPDLCSTATUS" MinLength="1" />
-                          
-                          <!-- CPDLC Plugin: Text Status -->
-                          <StripItem Type="CPDLCPLUGIN_TEXTSTATUS" />
-                          
                           <StripItem Type="FlightRules" />
                         </StripItems>
                       </StripLayoutLine>


### PR DESCRIPTION
Reverts https://github.com/vatSys/australia-dataset/pull/265 to avoid conflicting label items when the CPDLC Plugin is installed.
I'll add something to the CPDLC Plugin itself to add/remove the label items.